### PR TITLE
feat: account sharing model with visibility levels

### DIFF
--- a/drizzle/migrations/0002_outstanding_supreme_intelligence.sql
+++ b/drizzle/migrations/0002_outstanding_supreme_intelligence.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."account_visibility" AS ENUM('private', 'stats_only', 'full');--> statement-breakpoint
+DROP TABLE "core"."account_shares" CASCADE;--> statement-breakpoint
+ALTER TABLE "core"."bank_accounts" ADD COLUMN "visibility" "account_visibility" DEFAULT 'private' NOT NULL;--> statement-breakpoint
+ALTER TABLE "core"."transactions" ADD COLUMN "my_portion" numeric(4, 3);--> statement-breakpoint
+DROP TYPE "public"."share_status";

--- a/drizzle/migrations/0003_luxuriant_titania.sql
+++ b/drizzle/migrations/0003_luxuriant_titania.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "core"."csv_uploads" DROP CONSTRAINT "csv_uploads_bank_account_id_bank_accounts_id_fk";
+--> statement-breakpoint
+ALTER TABLE "core"."transaction_overrides" DROP CONSTRAINT "transaction_overrides_transaction_id_transactions_id_fk";
+--> statement-breakpoint
+ALTER TABLE "core"."transactions" DROP CONSTRAINT "transactions_bank_account_id_bank_accounts_id_fk";
+--> statement-breakpoint
+ALTER TABLE "core"."transactions" DROP CONSTRAINT "transactions_csv_upload_id_csv_uploads_id_fk";
+--> statement-breakpoint
+ALTER TABLE "core"."csv_uploads" ADD CONSTRAINT "csv_uploads_bank_account_id_bank_accounts_id_fk" FOREIGN KEY ("bank_account_id") REFERENCES "core"."bank_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "core"."transaction_overrides" ADD CONSTRAINT "transaction_overrides_transaction_id_transactions_id_fk" FOREIGN KEY ("transaction_id") REFERENCES "core"."transactions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "core"."transactions" ADD CONSTRAINT "transactions_bank_account_id_bank_accounts_id_fk" FOREIGN KEY ("bank_account_id") REFERENCES "core"."bank_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "core"."transactions" ADD CONSTRAINT "transactions_csv_upload_id_csv_uploads_id_fk" FOREIGN KEY ("csv_upload_id") REFERENCES "core"."csv_uploads"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1220 @@
+{
+  "id": "37ba340f-d83a-480b-b0fe-869a888a52f5",
+  "prevId": "467eb10f-b522-41d4-8a16-98a4a6041b62",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban_last4": {
+          "name": "iban_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_data'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "account_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_accounts_workspace_id_workspaces_id_fk": {
+          "name": "bank_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.categories": {
+      "name": "categories",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_workspace_id_workspaces_id_fk": {
+          "name": "categories_workspace_id_workspaces_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_column_mappings": {
+      "name": "csv_column_mappings",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_key": {
+          "name": "column_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_label": {
+          "name": "column_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_column_mappings_workspace_id_workspaces_id_fk": {
+          "name": "csv_column_mappings_workspace_id_workspaces_id_fk",
+          "tableFrom": "csv_column_mappings",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_uploads": {
+      "name": "csv_uploads",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged_count": {
+          "name": "flagged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_updates": {
+          "name": "status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_from": {
+          "name": "date_range_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_to": {
+          "name": "date_range_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_uploads_bank_account_id_bank_accounts_id_fk": {
+          "name": "csv_uploads_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "csv_uploads",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.invites": {
+      "name": "invites",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_workspace_id_workspaces_id_fk": {
+          "name": "invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transaction_overrides": {
+      "name": "transaction_overrides",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tx_override_user_idx": {
+          "name": "tx_override_user_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_overrides_transaction_id_transactions_id_fk": {
+          "name": "transaction_overrides_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_overrides",
+          "tableTo": "transactions",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transactions": {
+      "name": "transactions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csv_upload_id": {
+          "name": "csv_upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_date": {
+          "name": "accounting_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_original": {
+          "name": "amount_original",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency_original": {
+          "name": "currency_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditor_name": {
+          "name": "creditor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debtor_name": {
+          "name": "debtor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_confidence": {
+          "name": "category_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override": {
+          "name": "category_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override_by_id": {
+          "name": "category_override_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_transfer": {
+          "name": "is_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transfer_counterpart_id": {
+          "name": "transfer_counterpart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_by_id": {
+          "name": "transfer_linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_at": {
+          "name": "transfer_linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "my_portion": {
+          "name": "my_portion",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_opening_balance": {
+          "name": "is_opening_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "sync_source": {
+          "name": "sync_source",
+          "type": "sync_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_dedup_idx": {
+          "name": "transactions_dedup_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_accounting_date_idx": {
+          "name": "transactions_accounting_date_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accounting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_idx": {
+          "name": "transactions_transfer_idx",
+          "columns": [
+            {
+              "expression": "transfer_counterpart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_bank_account_id_bank_accounts_id_fk": {
+          "name": "transactions_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_csv_upload_id_csv_uploads_id_fk": {
+          "name": "transactions_csv_upload_id_csv_uploads_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "csv_uploads",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "csv_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.workspaces": {
+      "name": "workspaces",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_status": {
+      "name": "account_status",
+      "schema": "public",
+      "values": [
+        "no_data",
+        "active"
+      ]
+    },
+    "public.account_visibility": {
+      "name": "account_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "stats_only",
+        "full"
+      ]
+    },
+    "public.sync_source": {
+      "name": "sync_source",
+      "schema": "public",
+      "values": [
+        "csv_upload",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "posted",
+        "review"
+      ]
+    }
+  },
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1220 @@
+{
+  "id": "a56e497c-340d-4308-8d16-21acc5bb5f48",
+  "prevId": "37ba340f-d83a-480b-b0fe-869a888a52f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban_last4": {
+          "name": "iban_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_data'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "account_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_accounts_workspace_id_workspaces_id_fk": {
+          "name": "bank_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.categories": {
+      "name": "categories",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_workspace_id_workspaces_id_fk": {
+          "name": "categories_workspace_id_workspaces_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_column_mappings": {
+      "name": "csv_column_mappings",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_key": {
+          "name": "column_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_label": {
+          "name": "column_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_column_mappings_workspace_id_workspaces_id_fk": {
+          "name": "csv_column_mappings_workspace_id_workspaces_id_fk",
+          "tableFrom": "csv_column_mappings",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_uploads": {
+      "name": "csv_uploads",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged_count": {
+          "name": "flagged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_updates": {
+          "name": "status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_from": {
+          "name": "date_range_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_to": {
+          "name": "date_range_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_uploads_bank_account_id_bank_accounts_id_fk": {
+          "name": "csv_uploads_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "csv_uploads",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.invites": {
+      "name": "invites",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_workspace_id_workspaces_id_fk": {
+          "name": "invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transaction_overrides": {
+      "name": "transaction_overrides",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tx_override_user_idx": {
+          "name": "tx_override_user_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_overrides_transaction_id_transactions_id_fk": {
+          "name": "transaction_overrides_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_overrides",
+          "tableTo": "transactions",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transactions": {
+      "name": "transactions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csv_upload_id": {
+          "name": "csv_upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_date": {
+          "name": "accounting_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_original": {
+          "name": "amount_original",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency_original": {
+          "name": "currency_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditor_name": {
+          "name": "creditor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debtor_name": {
+          "name": "debtor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_confidence": {
+          "name": "category_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override": {
+          "name": "category_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override_by_id": {
+          "name": "category_override_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_transfer": {
+          "name": "is_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transfer_counterpart_id": {
+          "name": "transfer_counterpart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_by_id": {
+          "name": "transfer_linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_at": {
+          "name": "transfer_linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "my_portion": {
+          "name": "my_portion",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_opening_balance": {
+          "name": "is_opening_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "sync_source": {
+          "name": "sync_source",
+          "type": "sync_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_dedup_idx": {
+          "name": "transactions_dedup_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_accounting_date_idx": {
+          "name": "transactions_accounting_date_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accounting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_idx": {
+          "name": "transactions_transfer_idx",
+          "columns": [
+            {
+              "expression": "transfer_counterpart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_bank_account_id_bank_accounts_id_fk": {
+          "name": "transactions_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_csv_upload_id_csv_uploads_id_fk": {
+          "name": "transactions_csv_upload_id_csv_uploads_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "csv_uploads",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "csv_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.workspaces": {
+      "name": "workspaces",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_status": {
+      "name": "account_status",
+      "schema": "public",
+      "values": [
+        "no_data",
+        "active"
+      ]
+    },
+    "public.account_visibility": {
+      "name": "account_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "stats_only",
+        "full"
+      ]
+    },
+    "public.sync_source": {
+      "name": "sync_source",
+      "schema": "public",
+      "values": [
+        "csv_upload",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "posted",
+        "review"
+      ]
+    }
+  },
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775131907429,
       "tag": "0002_outstanding_supreme_intelligence",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1775158253998,
+      "tag": "0003_luxuriant_titania",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775036138266,
       "tag": "0001_mature_the_fallen",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1775131907429,
+      "tag": "0002_outstanding_supreme_intelligence",
+      "breakpoints": true
     }
   ]
 }

--- a/features/phase-2-account-sharing.md
+++ b/features/phase-2-account-sharing.md
@@ -17,11 +17,11 @@ Workspaces are **not** the sharing mechanism. They answer "who can potentially s
 
 Each `bankAccount` has a `visibility` field (enum) that controls what the workspace partner can see:
 
-| Value | Owner | Partner |
-|---|---|---|
-| `private` | Full access | Cannot see the account at all |
+| Value        | Owner       | Partner                                                                                         |
+| ------------ | ----------- | ----------------------------------------------------------------------------------------------- |
+| `private`    | Full access | Cannot see the account at all                                                                   |
 | `stats_only` | Full access | Sees aggregated data on dashboard (totals, category breakdown) — individual transactions hidden |
-| `full` | Full access | Sees everything, including individual transactions, and can upload CSVs |
+| `full`       | Full access | Sees everything, including individual transactions, and can upload CSVs                         |
 
 Default: `private` on creation.
 
@@ -55,7 +55,7 @@ Groups (linking transactions to other people and tracking debts/settlements) are
 
 ```typescript
 // Added
-visibility: accountVisibilityEnum('visibility').default('private').notNull()
+visibility: accountVisibilityEnum('visibility').default('private').notNull();
 // 'private' | 'stats_only' | 'full'
 ```
 
@@ -63,7 +63,7 @@ visibility: accountVisibilityEnum('visibility').default('private').notNull()
 
 ```typescript
 // Added — null means 100% mine
-myPortion: numeric('my_portion', { precision: 4, scale: 3 })
+myPortion: numeric('my_portion', { precision: 4, scale: 3 });
 ```
 
 ### Removed
@@ -80,6 +80,7 @@ myPortion: numeric('my_portion', { precision: 4, scale: 3 })
 ### `getAccessibleAccountIds(userId)`
 
 Returns account IDs the user can access:
+
 - All accounts they own (any visibility, including private)
 - Workspace accounts owned by others where `visibility IN ('stats_only', 'full')`
 
@@ -88,6 +89,7 @@ Queries by `workspaceId` — no join to `accountShares` needed.
 ### `canUploadToAccount(userId, accountId)` — new
 
 Returns `true` if:
+
 - User owns the account, OR
 - User is in the same workspace AND account has `visibility = 'full'`
 
@@ -106,6 +108,7 @@ npm run db:generate && npm run db:migrate
 ```
 
 This will:
+
 - Drop the `account_shares` table and `share_status` enum
 - Add `visibility` column to `bank_accounts`
 - Add `my_portion` column to `transactions`
@@ -124,8 +127,8 @@ Load the workspace partner's name (to display in the sharing UI):
 
 ```typescript
 const partner = await db.query.authUser.findFirst({
-    where: and(eq(authUser.workspaceId, user.workspaceId), ne(authUser.id, userId)),
-    columns: { id: true, name: true }
+	where: and(eq(authUser.workspaceId, user.workspaceId), ne(authUser.id, userId)),
+	columns: { id: true, name: true }
 });
 ```
 

--- a/features/phase-2-account-sharing.md
+++ b/features/phase-2-account-sharing.md
@@ -1,0 +1,173 @@
+# Phase 2 — Account Sharing Model
+
+> Implementation plan for issue #16.
+> Updated after architectural discussion — see below for rationale.
+
+---
+
+## Final model
+
+### Workspaces
+
+Workspaces define **who is connected to whom** — the couple unit. Both users share the same `workspaceId`. They also scope shared settings: categories and CSV column mappings are workspace-level.
+
+Workspaces are **not** the sharing mechanism. They answer "who can potentially see my accounts", not "which accounts are visible and how much."
+
+### Account visibility
+
+Each `bankAccount` has a `visibility` field (enum) that controls what the workspace partner can see:
+
+| Value | Owner | Partner |
+|---|---|---|
+| `private` | Full access | Cannot see the account at all |
+| `stats_only` | Full access | Sees aggregated data on dashboard (totals, category breakdown) — individual transactions hidden |
+| `full` | Full access | Sees everything, including individual transactions, and can upload CSVs |
+
+Default: `private` on creation.
+
+This replaces the `accountShares` table entirely. No pending/accepted/revoked lifecycle needed.
+
+### Expense splits (`myPortion`)
+
+Each transaction has an optional `myPortion` field (numeric, 0.0–1.0):
+
+- `null` → 100% the owner's expense (default)
+- `0.5` → owner paid the full amount but only half is theirs (e.g. paid for two)
+- `0.33` → owner paid for three people
+
+The dashboard uses `amount × COALESCE(myPortion, 1.0)` as the **effective expense** for the owner's personal view. This avoids building a full Splitwise-like debt-tracking system while still giving an accurate picture of personal spending.
+
+Groups (linking transactions to other people and tracking debts/settlements) are a future phase — see issue #21.
+
+---
+
+## What was removed
+
+- `accountShares` table — replaced by `bankAccounts.visibility`
+- `shareStatusEnum` — no longer needed
+- `canUpload` boolean — upload rights are now implicit: owner always, partner when `visibility = 'full'`
+
+---
+
+## Schema changes applied
+
+### `bankAccounts`
+
+```typescript
+// Added
+visibility: accountVisibilityEnum('visibility').default('private').notNull()
+// 'private' | 'stats_only' | 'full'
+```
+
+### `transactions`
+
+```typescript
+// Added — null means 100% mine
+myPortion: numeric('my_portion', { precision: 4, scale: 3 })
+```
+
+### Removed
+
+- `shareStatusEnum` enum
+- `accountShares` table + `accountSharesRelations`
+- `sharedAccountsBy` / `sharedAccountsWith` from `userRelations`
+- `shares` from `bankAccountsRelations`
+
+---
+
+## `access.ts` — updated helpers
+
+### `getAccessibleAccountIds(userId)`
+
+Returns account IDs the user can access:
+- All accounts they own (any visibility, including private)
+- Workspace accounts owned by others where `visibility IN ('stats_only', 'full')`
+
+Queries by `workspaceId` — no join to `accountShares` needed.
+
+### `canUploadToAccount(userId, accountId)` — new
+
+Returns `true` if:
+- User owns the account, OR
+- User is in the same workspace AND account has `visibility = 'full'`
+
+Used by the upload endpoint (Phase 3).
+
+---
+
+## Remaining implementation (not yet done)
+
+### Step 1 — Migration
+
+Run in a terminal (needs TTY):
+
+```bash
+npm run db:generate && npm run db:migrate
+```
+
+This will:
+- Drop the `account_shares` table and `share_status` enum
+- Add `visibility` column to `bank_accounts`
+- Add `my_portion` column to `transactions`
+
+### Step 2 — API: update `GET /api/accounts`
+
+The response already returns `isOwner`. No change needed for the list — access control is already handled via `getAccessibleAccountIds`.
+
+### Step 3 — API: `PATCH /api/accounts/[id]`
+
+Extend the existing handler to accept `visibility` in the body (owner only). Validate against the enum values.
+
+### Step 4 — Account Detail page (`+page.server.ts`)
+
+Load the workspace partner's name (to display in the sharing UI):
+
+```typescript
+const partner = await db.query.authUser.findFirst({
+    where: and(eq(authUser.workspaceId, user.workspaceId), ne(authUser.id, userId)),
+    columns: { id: true, name: true }
+});
+```
+
+Return `{ account, uploads, isOwner, partner }`.
+
+### Step 5 — Account Detail page (`+page.svelte`)
+
+Add a **Sharing** card between Upload History and Danger Zone (owner only):
+
+```
+SHARING
+─────────────────────────────────────
+○ Private         Only you can see this account
+○ Stats only      María can see totals and category breakdown
+● Full access     María can see all transactions and upload CSVs
+```
+
+A radio group with three options. On change, `PATCH /api/accounts/[id]` with the new visibility.
+
+### Step 6 — BankCard: "Shared" badge
+
+In `BankCard.svelte`, when `!account.isOwner`, show a small chip next to the account name:
+
+```
+bg-primary-100 text-primary-700  rounded-full px-2 py-0.5 text-xs  "Shared"
+```
+
+No API change needed — `isOwner` is already in the `GET /api/accounts` response.
+
+### Step 7 — Dashboard: stats_only aggregation
+
+When rendering dashboard data for accounts where the user is not the owner and `visibility = 'stats_only'`, return category totals and monthly summaries only — no individual transactions. The transaction list endpoint should return an empty array for these accounts when the requester is not the owner.
+
+---
+
+## Future: expense groups (issue #21)
+
+A future phase will add proper group expense tracking:
+
+- `groups` table: `id, name, workspaceId`
+- `group_members` table: `groupId, userId` (supports external people by name/email)
+- Transactions can be tagged with a `groupId`
+- Settlement tracking within the group
+
+The `myPortion` field on transactions is designed to work independently of groups — it can be set manually without a group, or derived automatically from a group split in the future.

--- a/scripts/seed-member.ts
+++ b/scripts/seed-member.ts
@@ -1,0 +1,142 @@
+/**
+ * Creates a second member account and assigns them to an existing workspace.
+ * Run once after seed-owner.ts to set up a second user for testing:
+ *
+ *   npx tsx scripts/seed-member.ts \
+ *     --email=partner@example.com \
+ *     --name="María García" \
+ *     --password=yourpassword \
+ *     --workspaceId=<id from seed-owner output>
+ *
+ * The workspaceId is printed when running seed-owner.ts.
+ * You can also find it in Drizzle Studio: npm run db:studio
+ */
+
+// Load .env file (Node 20.12+ built-in)
+try {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(process as any).loadEnvFile('.env');
+} catch {
+	// Env vars may already be set in the shell
+}
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+	console.error('Error: DATABASE_URL is not set. Make sure .env is present.');
+	process.exit(1);
+}
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { eq } from 'drizzle-orm';
+
+const { betterAuth } = await import('better-auth');
+const { drizzleAdapter } = await import('better-auth/adapters/drizzle');
+
+// Parse CLI args
+const args = Object.fromEntries(
+	process.argv
+		.slice(2)
+		.filter((a) => a.startsWith('--'))
+		.map((a) => {
+			const [key, ...rest] = a.slice(2).split('=');
+			return [key, rest.join('=')];
+		})
+);
+
+const email = args['email'];
+const name = args['name'];
+const password = args['password'];
+const workspaceId = args['workspaceId'];
+
+if (!email || !name || !password || !workspaceId) {
+	console.error(
+		'Usage: npx tsx scripts/seed-member.ts --email=... --name=... --password=... --workspaceId=...'
+	);
+	process.exit(1);
+}
+
+// Set up DB client
+const client = postgres(DATABASE_URL);
+const { authUser, authSession, authAccount, authVerification, workspaces } =
+	await import('../src/lib/server/db/schema.js');
+const db = drizzle(client, { schema: { authUser, workspaces } });
+
+// Verify the workspace exists
+const workspace = await db.query.workspaces.findFirst({ where: eq(workspaces.id, workspaceId) });
+if (!workspace) {
+	console.error(`Error: Workspace "${workspaceId}" not found. Check the ID and try again.`);
+	process.exit(1);
+}
+
+// Check workspace does not already have 2 members
+const existingMembers = await db
+	.select({ id: authUser.id })
+	.from(authUser)
+	.where(eq(authUser.workspaceId, workspaceId));
+
+if (existingMembers.length >= 2) {
+	console.error(
+		`Error: Workspace "${workspace.name}" already has ${existingMembers.length} members (max 2).`
+	);
+	process.exit(1);
+}
+
+// Minimal auth instance — must match auth.ts schema mapping
+const auth = betterAuth({
+	database: drizzleAdapter(db as never, {
+		provider: 'pg',
+		schema: {
+			user: authUser,
+			session: authSession,
+			account: authAccount,
+			verification: authVerification
+		}
+	}),
+	emailAndPassword: { enabled: true },
+	user: {
+		additionalFields: {
+			workspaceId: { type: 'string', required: false, input: false },
+			role: { type: 'string', required: false, defaultValue: 'member', input: false }
+		}
+	}
+});
+
+console.log(`Creating member account for ${email}...`);
+
+try {
+	await auth.api.signUpEmail({ body: { email, password, name } });
+} catch (err: unknown) {
+	const message = err instanceof Error ? err.message : String(err);
+	if (
+		message.toLowerCase().includes('already exists') ||
+		message.toLowerCase().includes('duplicate')
+	) {
+		console.log('User already exists, continuing to workspace assignment...');
+	} else {
+		console.error('Failed to create user:', message);
+		process.exit(1);
+	}
+}
+
+// Fetch the created user
+const createdUser = await db.query.authUser.findFirst({ where: eq(authUser.email, email) });
+if (!createdUser) {
+	console.error('Could not find user after creation. Aborting.');
+	process.exit(1);
+}
+
+// Assign to workspace as member
+await db
+	.update(authUser)
+	.set({ role: 'member', workspaceId })
+	.where(eq(authUser.id, createdUser.id));
+
+console.log(`\nMember account created successfully!`);
+console.log(`  Name:        ${name}`);
+console.log(`  Email:       ${email}`);
+console.log(`  User ID:     ${createdUser.id}`);
+console.log(`  Workspace:   ${workspaceId} (${workspace.name})`);
+console.log(`\nThey can now log in at http://localhost:5173/login`);
+
+await client.end();

--- a/src/lib/components/accounts/BankCard.svelte
+++ b/src/lib/components/accounts/BankCard.svelte
@@ -83,9 +83,18 @@
 								autofocus
 							/>
 						{:else}
-							<p class="truncate text-sm leading-tight font-medium text-text-primary">
-								{account.displayName}
-							</p>
+							<div class="flex items-center gap-1.5">
+								<p class="truncate text-sm leading-tight font-medium text-text-primary">
+									{account.displayName}
+								</p>
+								{#if !account.isOwner}
+									<span
+										class="shrink-0 rounded-sm bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-700"
+									>
+										Shared
+									</span>
+								{/if}
+							</div>
 						{/if}
 						<p class="mt-0.5 text-xs text-text-tertiary">
 							···{account.ibanLast4} · {account.currency}

--- a/src/lib/server/db/access.ts
+++ b/src/lib/server/db/access.ts
@@ -29,6 +29,32 @@ export async function getAccessibleAccountIds(userId: string): Promise<string[]>
 }
 
 /**
+ * Returns account IDs where the user can view individual transactions:
+ * - All accounts they own (any visibility)
+ * - Workspace accounts with visibility = 'full' (stats_only excluded)
+ */
+export async function getFullAccessAccountIds(userId: string): Promise<string[]> {
+	const user = await db.query.authUser.findFirst({
+		where: eq(authUser.id, userId),
+		columns: { workspaceId: true }
+	});
+	if (!user?.workspaceId) return [];
+
+	const rows = await db
+		.select({ id: bankAccounts.id })
+		.from(bankAccounts)
+		.where(
+			and(
+				eq(bankAccounts.workspaceId, user.workspaceId),
+				isNull(bankAccounts.deletedAt),
+				or(eq(bankAccounts.ownerUserId, userId), eq(bankAccounts.visibility, 'full'))
+			)
+		);
+
+	return rows.map((r) => r.id);
+}
+
+/**
  * Returns true if the user can upload CSVs to the given account:
  * - They own the account, OR
  * - They are a workspace member and the account has 'full' visibility

--- a/src/lib/server/db/access.ts
+++ b/src/lib/server/db/access.ts
@@ -1,23 +1,51 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, ne, or } from 'drizzle-orm';
 import { db } from './index.js';
-import { bankAccounts, accountShares } from './schema.js';
+import { authUser, bankAccounts } from './schema.js';
 
 /**
  * Returns all bank account IDs the given user can access:
- * accounts they own + accounts shared with them (accepted only).
+ * - All accounts they own (any visibility)
+ * - Workspace accounts owned by others where visibility is 'stats_only' or 'full'
  */
 export async function getAccessibleAccountIds(userId: string): Promise<string[]> {
-	const [owned, shared] = await Promise.all([
-		db
-			.select({ id: bankAccounts.id })
-			.from(bankAccounts)
-			.where(and(eq(bankAccounts.ownerUserId, userId), isNull(bankAccounts.deletedAt))),
+	const user = await db.query.authUser.findFirst({
+		where: eq(authUser.id, userId),
+		columns: { workspaceId: true }
+	});
+	if (!user?.workspaceId) return [];
 
-		db
-			.select({ id: accountShares.bankAccountId })
-			.from(accountShares)
-			.where(and(eq(accountShares.sharedWithId, userId), eq(accountShares.status, 'accepted')))
-	]);
+	const rows = await db
+		.select({ id: bankAccounts.id })
+		.from(bankAccounts)
+		.where(
+			and(
+				eq(bankAccounts.workspaceId, user.workspaceId),
+				isNull(bankAccounts.deletedAt),
+				or(eq(bankAccounts.ownerUserId, userId), ne(bankAccounts.visibility, 'private'))
+			)
+		);
 
-	return [...owned, ...shared].map((r) => r.id);
+	return rows.map((r) => r.id);
+}
+
+/**
+ * Returns true if the user can upload CSVs to the given account:
+ * - They own the account, OR
+ * - They are a workspace member and the account has 'full' visibility
+ */
+export async function canUploadToAccount(userId: string, accountId: string): Promise<boolean> {
+	const user = await db.query.authUser.findFirst({
+		where: eq(authUser.id, userId),
+		columns: { workspaceId: true }
+	});
+	if (!user?.workspaceId) return false;
+
+	const account = await db.query.bankAccounts.findFirst({
+		where: and(eq(bankAccounts.id, accountId), isNull(bankAccounts.deletedAt)),
+		columns: { ownerUserId: true, workspaceId: true, visibility: true }
+	});
+	if (!account) return false;
+	if (account.ownerUserId === userId) return true;
+
+	return account.workspaceId === user.workspaceId && account.visibility === 'full';
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -93,7 +93,7 @@ export const csvUploads = coreSchema.table('csv_uploads', {
 		.$defaultFn(() => crypto.randomUUID()),
 	bankAccountId: text('bank_account_id')
 		.notNull()
-		.references(() => bankAccounts.id),
+		.references(() => bankAccounts.id, { onDelete: 'cascade' }),
 	// userId references auth.user.id — enforced at app layer
 	userId: text('user_id').notNull(),
 	filename: text('filename').notNull(),
@@ -119,8 +119,8 @@ export const transactions = coreSchema.table(
 			.$defaultFn(() => crypto.randomUUID()),
 		bankAccountId: text('bank_account_id')
 			.notNull()
-			.references(() => bankAccounts.id),
-		csvUploadId: text('csv_upload_id').references(() => csvUploads.id),
+			.references(() => bankAccounts.id, { onDelete: 'cascade' }),
+		csvUploadId: text('csv_upload_id').references(() => csvUploads.id, { onDelete: 'set null' }),
 		externalId: text('external_id'),
 
 		accountingDate: timestamp('accounting_date', { mode: 'date' }).notNull(),
@@ -187,7 +187,7 @@ export const transactionOverrides = coreSchema.table(
 			.$defaultFn(() => crypto.randomUUID()),
 		transactionId: text('transaction_id')
 			.notNull()
-			.references(() => transactions.id),
+			.references(() => transactions.id, { onDelete: 'cascade' }),
 		// userId references auth.user.id — enforced at app layer
 		userId: text('user_id').notNull(),
 		category: text('category').notNull(),

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -21,11 +21,10 @@ const coreSchema = pgSchema('core');
 
 export const accountStatusEnum = pgEnum('account_status', ['no_data', 'active']);
 
-export const shareStatusEnum = pgEnum('share_status', [
-	'pending',
-	'accepted',
-	'declined',
-	'revoked'
+export const accountVisibilityEnum = pgEnum('account_visibility', [
+	'private',
+	'stats_only',
+	'full'
 ]);
 
 export const transactionStatusEnum = pgEnum('transaction_status', ['pending', 'posted', 'review']);
@@ -80,25 +79,10 @@ export const bankAccounts = coreSchema.table('bank_accounts', {
 	currency: text('currency').default('EUR').notNull(),
 	currentBalance: numeric('current_balance', { precision: 15, scale: 4 }).default('0').notNull(),
 	status: accountStatusEnum('status').default('no_data').notNull(),
+	// Controls partner access: private = owner only, stats_only = aggregated data, full = all transactions
+	visibility: accountVisibilityEnum('visibility').default('private').notNull(),
 	deletedAt: timestamp('deleted_at'),
 	createdAt: timestamp('created_at').defaultNow().notNull()
-});
-
-// ─── Account shares ────────────────────────────────────────────────────────
-
-export const accountShares = coreSchema.table('account_shares', {
-	id: text('id')
-		.primaryKey()
-		.$defaultFn(() => crypto.randomUUID()),
-	bankAccountId: text('bank_account_id')
-		.notNull()
-		.references(() => bankAccounts.id),
-	// sharedById / sharedWithId reference auth.user.id — enforced at app layer
-	sharedById: text('shared_by_id').notNull(),
-	sharedWithId: text('shared_with_id').notNull(),
-	status: shareStatusEnum('status').default('pending').notNull(),
-	requestedAt: timestamp('requested_at').defaultNow().notNull(),
-	respondedAt: timestamp('responded_at')
 });
 
 // ─── CSV uploads ───────────────────────────────────────────────────────────
@@ -170,6 +154,10 @@ export const transactions = coreSchema.table(
 		// transferLinkedById references auth.user.id — enforced at app layer
 		transferLinkedById: text('transfer_linked_by_id'),
 		transferLinkedAt: timestamp('transfer_linked_at'),
+
+		// Expense split — null means 100% mine; 0.5 means I pay half, etc.
+		// Used for dashboard "effective expense" calculation without a full Splitwise model.
+		myPortion: numeric('my_portion', { precision: 4, scale: 3 }),
 
 		// System flags
 		isOpeningBalance: boolean('is_opening_balance').default(false).notNull(),
@@ -256,25 +244,7 @@ export const bankAccountsRelations = relations(bankAccounts, ({ one, many }) => 
 	owner: one(authUser, { fields: [bankAccounts.ownerUserId], references: [authUser.id] }),
 	workspace: one(workspaces, { fields: [bankAccounts.workspaceId], references: [workspaces.id] }),
 	transactions: many(transactions),
-	shares: many(accountShares),
 	csvUploads: many(csvUploads)
-}));
-
-export const accountSharesRelations = relations(accountShares, ({ one }) => ({
-	bankAccount: one(bankAccounts, {
-		fields: [accountShares.bankAccountId],
-		references: [bankAccounts.id]
-	}),
-	sharedBy: one(authUser, {
-		fields: [accountShares.sharedById],
-		references: [authUser.id],
-		relationName: 'SharedBy'
-	}),
-	sharedWith: one(authUser, {
-		fields: [accountShares.sharedWithId],
-		references: [authUser.id],
-		relationName: 'SharedWith'
-	})
 }));
 
 export const csvUploadsRelations = relations(csvUploads, ({ one, many }) => ({
@@ -337,7 +307,5 @@ export const userRelations = relations(authUser, ({ many }) => ({
 	csvUploads: many(csvUploads),
 	paidTransactions: many(transactions),
 	transactionOverrides: many(transactionOverrides),
-	invitesSent: many(invites),
-	sharedAccountsBy: many(accountShares, { relationName: 'SharedBy' }),
-	sharedAccountsWith: many(accountShares, { relationName: 'SharedWith' })
+	invitesSent: many(invites)
 }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+export type AccountVisibility = 'private' | 'stats_only' | 'full';
+
 export interface Account {
 	id: string;
 	displayName: string;
@@ -5,6 +7,7 @@ export interface Account {
 	ibanLast4: string | null;
 	currency: string;
 	status: string | null;
+	visibility: AccountVisibility;
 	isOwner: boolean;
 	currentBalance: number;
 	txCount: number;

--- a/src/routes/(app)/accounts/+page.server.ts
+++ b/src/routes/(app)/accounts/+page.server.ts
@@ -24,6 +24,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 						currency: bankAccounts.currency,
 						currentBalance: bankAccounts.currentBalance,
 						status: bankAccounts.status,
+						visibility: bankAccounts.visibility,
 						ownerUserId: bankAccounts.ownerUserId,
 						createdAt: bankAccounts.createdAt,
 						txCount: count(transactions.id),

--- a/src/routes/(app)/accounts/[id]/+page.server.ts
+++ b/src/routes/(app)/accounts/[id]/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNull, ne } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 import { db } from '$lib/server/db/index.js';
-import { bankAccounts, csvUploads } from '$lib/server/db/schema.js';
+import { authUser, bankAccounts, csvUploads } from '$lib/server/db/schema.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
@@ -16,16 +16,31 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	});
 	if (!account) error(404, 'Account not found');
 
-	const uploads = await db
-		.select()
-		.from(csvUploads)
-		.where(eq(csvUploads.bankAccountId, params.id))
-		.orderBy(desc(csvUploads.uploadedAt))
-		.limit(20);
+	const isOwner = account.ownerUserId === locals.user.id;
+
+	const [uploads, partner] = await Promise.all([
+		db
+			.select()
+			.from(csvUploads)
+			.where(eq(csvUploads.bankAccountId, params.id))
+			.orderBy(desc(csvUploads.uploadedAt))
+			.limit(20),
+
+		locals.user.workspaceId
+			? db.query.authUser.findFirst({
+					where: and(
+						eq(authUser.workspaceId, locals.user.workspaceId),
+						ne(authUser.id, locals.user.id)
+					),
+					columns: { id: true, name: true }
+				})
+			: Promise.resolve(null)
+	]);
 
 	return {
 		account: { ...account, currentBalance: parseFloat(account.currentBalance) },
 		uploads,
-		isOwner: account.ownerUserId === locals.user.id
+		isOwner,
+		partner: partner ?? null
 	};
 };

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { goto, invalidateAll } from '$app/navigation';
 	import { formatDistanceToNow, format } from 'date-fns';
-	import { ArrowLeft, Upload, Trash2, Check, X } from '@lucide/svelte';
+	import { ArrowLeft, Upload, Trash2, Check, X, Lock, BarChart2, Eye } from '@lucide/svelte';
 	import Amount from '$lib/components/Amount.svelte';
 	import BankLogo from '$lib/components/BankLogo.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import type { PageData } from './$types';
+	import type { AccountVisibility } from '$lib/types';
 
 	let { data }: { data: PageData } = $props();
 
@@ -15,6 +16,7 @@
 	let renameValue = $state(data.account.displayName);
 	let renameSubmitting = $state(false);
 	let deleteConfirm = $state(false);
+	let visibilityUpdating = $state(false);
 
 	async function submitRename() {
 		if (!renameValue.trim() || renameValue === data.account.displayName) {
@@ -38,6 +40,18 @@
 		goto('/accounts');
 	}
 
+	async function setVisibility(v: AccountVisibility) {
+		if (v === data.account.visibility || visibilityUpdating) return;
+		visibilityUpdating = true;
+		await fetch(`/api/accounts/${data.account.id}`, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ visibility: v })
+		});
+		visibilityUpdating = false;
+		await invalidateAll();
+	}
+
 	function formatUploadRange(from: Date | string | null, to: Date | string | null): string {
 		if (!from) return '—';
 		const f = new Date(from);
@@ -47,6 +61,32 @@
 		}
 		return `${format(f, 'MMM yyyy')} – ${format(t, 'MMM yyyy')}`;
 	}
+
+	const visibilityOptions: {
+		value: AccountVisibility;
+		label: string;
+		description: string;
+		icon: typeof Lock;
+	}[] = [
+		{
+			value: 'private',
+			label: 'Private',
+			description: 'Only you can see this account',
+			icon: Lock
+		},
+		{
+			value: 'stats_only',
+			label: 'Stats only',
+			description: `${data.partner?.name ?? 'Your partner'} sees totals and category breakdowns, but not individual transactions`,
+			icon: BarChart2
+		},
+		{
+			value: 'full',
+			label: 'Full access',
+			description: `${data.partner?.name ?? 'Your partner'} can see all transactions and upload CSVs`,
+			icon: Eye
+		}
+	];
 </script>
 
 <div class="max-w-2xl px-4 py-6 md:px-8 md:py-8">
@@ -101,6 +141,13 @@
 					<h1 class="truncate text-xl font-semibold text-text-primary">
 						{data.account.displayName}
 					</h1>
+					{#if !data.isOwner}
+						<span
+							class="shrink-0 rounded-sm bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-700"
+						>
+							Shared
+						</span>
+					{/if}
 					{#if data.isOwner}
 						<button
 							onclick={() => (renaming = true)}
@@ -139,48 +186,108 @@
 		</span>
 	</div>
 
-	<!-- Upload history -->
-	<Card.Root class="mb-6 border-border bg-surface">
-		<Card.Header class="pb-3">
-			<div class="flex items-center justify-between">
+	<!-- Upload history (owner, or full-access partner) -->
+	{#if data.isOwner || data.account.visibility === 'full'}
+		<Card.Root class="mb-6 border-border bg-surface">
+			<Card.Header class="pb-3">
+				<div class="flex items-center justify-between">
+					<Card.Title class="text-sm font-semibold tracking-widest text-text-tertiary uppercase">
+						Upload history
+					</Card.Title>
+					<Button
+						size="sm"
+						variant="outline"
+						class="gap-1.5 text-xs"
+						disabled
+						title="Coming in Phase 3d"
+					>
+						<Upload size={13} />
+						Upload CSV
+					</Button>
+				</div>
+			</Card.Header>
+			<Card.Content class="pt-0">
+				{#if data.uploads.length === 0}
+					<p class="py-4 text-center text-sm text-text-tertiary">No uploads yet.</p>
+				{:else}
+					<div class="divide-y divide-border">
+						{#each data.uploads as upload (upload.id)}
+							<div class="flex items-center justify-between gap-4 py-3 text-sm">
+								<div class="min-w-0">
+									<p class="truncate font-medium text-text-primary">{upload.filename}</p>
+									<p class="mt-0.5 text-xs text-text-tertiary">
+										{formatUploadRange(upload.dateRangeFrom, upload.dateRangeTo)}
+									</p>
+								</div>
+								<div class="shrink-0 text-right text-xs text-text-tertiary">
+									<p class="font-medium text-text-secondary">{upload.importedCount} imported</p>
+									<p>{formatDistanceToNow(new Date(upload.uploadedAt), { addSuffix: true })}</p>
+								</div>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	{/if}
+
+	<!-- Sharing (owner only) -->
+	{#if data.isOwner && data.partner}
+		<Card.Root class="mb-6 border-border bg-surface">
+			<Card.Header class="pb-3">
 				<Card.Title class="text-sm font-semibold tracking-widest text-text-tertiary uppercase">
-					Upload history
+					Sharing
 				</Card.Title>
-				<Button
-					size="sm"
-					variant="outline"
-					class="gap-1.5 text-xs"
-					disabled
-					title="Coming in Phase 3d"
-				>
-					<Upload size={13} />
-					Upload CSV
-				</Button>
-			</div>
-		</Card.Header>
-		<Card.Content class="pt-0">
-			{#if data.uploads.length === 0}
-				<p class="py-4 text-center text-sm text-text-tertiary">No uploads yet.</p>
-			{:else}
-				<div class="divide-y divide-border">
-					{#each data.uploads as upload (upload.id)}
-						<div class="flex items-center justify-between gap-4 py-3 text-sm">
-							<div class="min-w-0">
-								<p class="truncate font-medium text-text-primary">{upload.filename}</p>
-								<p class="mt-0.5 text-xs text-text-tertiary">
-									{formatUploadRange(upload.dateRangeFrom, upload.dateRangeTo)}
-								</p>
+			</Card.Header>
+			<Card.Content class="pt-0">
+				<div class="flex flex-col gap-2">
+					{#each visibilityOptions as option (option.value)}
+						{@const active = data.account.visibility === option.value}
+						<button
+							onclick={() => setVisibility(option.value)}
+							disabled={visibilityUpdating}
+							class="flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors
+							{active
+								? 'border-primary-300 bg-primary-50'
+								: 'border-border bg-surface hover:bg-surface-raised'}
+							{visibilityUpdating ? 'opacity-50' : ''}"
+						>
+							<div
+								class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2
+								{active ? 'border-primary-500' : 'border-border-strong'}"
+							>
+								{#if active}
+									<span class="h-2 w-2 rounded-full bg-primary-500"></span>
+								{/if}
 							</div>
-							<div class="shrink-0 text-right text-xs text-text-tertiary">
-								<p class="font-medium text-text-secondary">{upload.importedCount} imported</p>
-								<p>{formatDistanceToNow(new Date(upload.uploadedAt), { addSuffix: true })}</p>
+							<div class="min-w-0 flex-1">
+								<div class="flex items-center gap-1.5">
+									<option.icon size={13} class="shrink-0 text-text-secondary" />
+									<p class="text-sm font-medium text-text-primary">{option.label}</p>
+								</div>
+								<p class="mt-0.5 text-xs text-text-tertiary">{option.description}</p>
 							</div>
-						</div>
+						</button>
 					{/each}
 				</div>
-			{/if}
-		</Card.Content>
-	</Card.Root>
+			</Card.Content>
+		</Card.Root>
+	{:else if !data.isOwner}
+		<!-- Sharee note -->
+		<Card.Root class="mb-6 border-border bg-surface">
+			<Card.Content class="py-4">
+				<p class="text-sm text-text-secondary">
+					This account is shared with you
+					{#if data.account.visibility === 'stats_only'}
+						in <span class="font-medium text-text-primary">stats only</span> mode — individual transactions
+						are private.
+					{:else}
+						with <span class="font-medium text-text-primary">full access</span>.
+					{/if}
+				</p>
+			</Card.Content>
+		</Card.Root>
+	{/if}
 
 	<!-- Danger zone (owner only) -->
 	{#if data.isOwner}

--- a/src/routes/(app)/accounts/[id]/+page.svelte
+++ b/src/routes/(app)/accounts/[id]/+page.svelte
@@ -247,9 +247,7 @@
 							onclick={() => setVisibility(option.value)}
 							disabled={visibilityUpdating}
 							class="flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors
-							{active
-								? 'border-primary-300 bg-primary-50'
-								: 'border-border bg-surface hover:bg-surface-raised'}
+							{active ? 'border-primary-300 bg-primary-50' : 'border-border bg-surface hover:bg-surface-raised'}
 							{visibilityUpdating ? 'opacity-50' : ''}"
 						>
 							<div

--- a/src/routes/(app)/transactions/+page.server.ts
+++ b/src/routes/(app)/transactions/+page.server.ts
@@ -3,13 +3,13 @@ import { and, eq, inArray, isNull } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts } from '$lib/server/db/schema.js';
-import { getAccessibleAccountIds } from '$lib/server/db/access.js';
+import { getFullAccessAccountIds } from '$lib/server/db/access.js';
 import { queryTransactions, type TxFilter } from '$lib/server/db/queries.js';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
 	if (!locals.user) error(401);
 
-	const accessibleIds = await getAccessibleAccountIds(locals.user.id);
+	const accessibleIds = await getFullAccessAccountIds(locals.user.id);
 
 	const q = url.searchParams.get('q') ?? '';
 	const accountId = url.searchParams.get('accountId') ?? '';

--- a/src/routes/api/accounts/+server.ts
+++ b/src/routes/api/accounts/+server.ts
@@ -28,6 +28,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 			currency: bankAccounts.currency,
 			currentBalance: bankAccounts.currentBalance,
 			status: bankAccounts.status,
+			visibility: bankAccounts.visibility,
 			ownerUserId: bankAccounts.ownerUserId,
 			createdAt: bankAccounts.createdAt,
 			txCount: count(transactions.id),

--- a/src/routes/api/accounts/[id]/+server.ts
+++ b/src/routes/api/accounts/[id]/+server.ts
@@ -43,7 +43,11 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 		.update(bankAccounts)
 		.set(patch)
 		.where(eq(bankAccounts.id, params.id))
-		.returning({ id: bankAccounts.id, displayName: bankAccounts.displayName, visibility: bankAccounts.visibility });
+		.returning({
+			id: bankAccounts.id,
+			displayName: bankAccounts.displayName,
+			visibility: bankAccounts.visibility
+		});
 
 	return json(updated);
 };

--- a/src/routes/api/accounts/[id]/+server.ts
+++ b/src/routes/api/accounts/[id]/+server.ts
@@ -53,17 +53,16 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 };
 
 // ─── DELETE /api/accounts/[id] ────────────────────────────────────────────────
-// Soft-delete an account. Owner only.
+// Hard-delete an account and all its data. Owner only.
+// Postgres ON DELETE CASCADE handles the rest:
+//   bankAccounts → csvUploads, transactions → transactionOverrides
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
 	if (!locals.user) throw error(401, 'Unauthorized');
 
 	await getOwnedAccount(params.id, locals.user.id);
 
-	await db
-		.update(bankAccounts)
-		.set({ deletedAt: new Date() })
-		.where(eq(bankAccounts.id, params.id));
+	await db.delete(bankAccounts).where(eq(bankAccounts.id, params.id));
 
 	return new Response(null, { status: 204 });
 };

--- a/src/routes/api/accounts/[id]/+server.ts
+++ b/src/routes/api/accounts/[id]/+server.ts
@@ -16,22 +16,34 @@ async function getOwnedAccount(accountId: string, userId: string) {
 	return account;
 }
 
+const VALID_VISIBILITY = new Set(['private', 'stats_only', 'full']);
+
 // ─── PATCH /api/accounts/[id] ─────────────────────────────────────────────────
-// Rename an account. Owner only.
+// Update display name and/or visibility. Owner only.
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	if (!locals.user) throw error(401, 'Unauthorized');
 
 	await getOwnedAccount(params.id, locals.user.id);
 
-	const { displayName } = await request.json();
-	if (!displayName?.trim()) throw error(400, 'displayName is required');
+	const body = await request.json();
+	const { displayName, visibility } = body;
+
+	if (!displayName && !visibility) throw error(400, 'Nothing to update');
+	if (displayName !== undefined && !displayName?.trim())
+		throw error(400, 'displayName cannot be empty');
+	if (visibility !== undefined && !VALID_VISIBILITY.has(visibility))
+		throw error(400, 'visibility must be private | stats_only | full');
+
+	const patch: Record<string, unknown> = {};
+	if (displayName) patch.displayName = displayName.trim();
+	if (visibility) patch.visibility = visibility;
 
 	const [updated] = await db
 		.update(bankAccounts)
-		.set({ displayName: displayName.trim() })
+		.set(patch)
 		.where(eq(bankAccounts.id, params.id))
-		.returning({ id: bankAccounts.id, displayName: bankAccounts.displayName });
+		.returning({ id: bankAccounts.id, displayName: bankAccounts.displayName, visibility: bankAccounts.visibility });
 
 	return json(updated);
 };

--- a/src/routes/api/transactions/+server.ts
+++ b/src/routes/api/transactions/+server.ts
@@ -1,6 +1,6 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getAccessibleAccountIds } from '$lib/server/db/access.js';
+import { getFullAccessAccountIds } from '$lib/server/db/access.js';
 import { queryTransactions, type TxFilter } from '$lib/server/db/queries.js';
 
 // ─── GET /api/transactions ────────────────────────────────────────────────────
@@ -15,7 +15,8 @@ import { queryTransactions, type TxFilter } from '$lib/server/db/queries.js';
 export const GET: RequestHandler = async ({ locals, url }) => {
 	if (!locals.user) throw error(401, 'Unauthorized');
 
-	const accessibleIds = await getAccessibleAccountIds(locals.user.id);
+	// Use full-access IDs only — stats_only accounts are excluded from transaction listing
+	const accessibleIds = await getFullAccessAccountIds(locals.user.id);
 
 	const q = url.searchParams.get('q') ?? '';
 	const accountId = url.searchParams.get('accountId') ?? '';


### PR DESCRIPTION
## Summary

Implements issue #16 — account sharing between workspace members, replacing the original `accountShares` table design with a simpler `visibility` field directly on `bankAccounts`.

- Replace `accountShares` table + `shareStatusEnum` with `visibility: 'private' | 'stats_only' | 'full'` on `bankAccounts` (default `private`)
- Add `myPortion` (nullable numeric 0.0–1.0) to `transactions` for lightweight expense split annotations — no full Splitwise model needed (future groups tracked in #21)
- Add `ON DELETE CASCADE` on `csvUploads → bankAccounts`, `transactions → bankAccounts`, `transactionOverrides → transactions`; `ON DELETE SET NULL` on `transactions → csvUploads` — account deletion now cascades automatically through Postgres
- Rewrite `getAccessibleAccountIds` to use `workspaceId` + `visibility`; add `getFullAccessAccountIds` (excludes `stats_only`) used by the transactions endpoint; add `canUploadToAccount` for Phase 3
- Extend `PATCH /api/accounts/[id]` to accept `visibility` (owner only)
- Simplify `DELETE /api/accounts/[id]` to a single statement — cascade handles the rest
- Account Detail page: Sharing card with 3-option radio selector (Private / Stats only / Full access), owner only; partner sees read-only access note; upload history hidden from `stats_only` partners
- `BankCard`: "Shared" badge on accounts the user doesn't own
- Transactions page and API both use `getFullAccessAccountIds` — `stats_only` accounts excluded from transaction listing for non-owners
- Add `scripts/seed-member.ts` for creating a second workspace member without the invite flow
- Document full model + rationale in `features/phase-2-account-sharing.md`

Closes #16

## Pending after merge

- Run `npm run db:generate && npm run db:migrate` to apply schema changes
- Invite flow (#22) — one-time link for inviting members without email dependency
- Stats-only aggregated dashboard view (Phase 4–7)