### PR TITLE
feat: Bankinter ES parser (XLSX) + opening balance fix + original order

### DIFF
--- a/drizzle/migrations/0006_add_original_order_to_transactions.sql
+++ b/drizzle/migrations/0006_add_original_order_to_transactions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "core"."transactions" ADD COLUMN "original_order" integer;

--- a/drizzle/migrations/meta/0006_snapshot.json
+++ b/drizzle/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1422 @@
+{
+  "id": "2429b383-9ddb-464a-8018-4c5d66db9126",
+  "prevId": "e221cd1c-778a-4073-9d46-8c14420702d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban_last4": {
+          "name": "iban_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_data'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "account_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_accounts_workspace_id_workspaces_id_fk": {
+          "name": "bank_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.categories": {
+      "name": "categories",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_workspace_id_workspaces_id_fk": {
+          "name": "categories_workspace_id_workspaces_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_column_mappings": {
+      "name": "csv_column_mappings",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_key": {
+          "name": "column_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_label": {
+          "name": "column_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_column_mappings_workspace_id_workspaces_id_fk": {
+          "name": "csv_column_mappings_workspace_id_workspaces_id_fk",
+          "tableFrom": "csv_column_mappings",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_uploads": {
+      "name": "csv_uploads",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged_count": {
+          "name": "flagged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_updates": {
+          "name": "status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_from": {
+          "name": "date_range_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_to": {
+          "name": "date_range_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_uploads_bank_account_id_bank_accounts_id_fk": {
+          "name": "csv_uploads_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "csv_uploads",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.currency_conversions": {
+      "name": "currency_conversions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_account_id": {
+          "name": "from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_amount": {
+          "name": "from_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_amount": {
+          "name": "to_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "conversion_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "from_transaction_id": {
+          "name": "from_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_transaction_id": {
+          "name": "to_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "currency_conversions_to_account_idx": {
+          "name": "currency_conversions_to_account_idx",
+          "columns": [
+            {
+              "expression": "to_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "currency_conversions_workspace_id_workspaces_id_fk": {
+          "name": "currency_conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "currency_conversions_from_account_id_bank_accounts_id_fk": {
+          "name": "currency_conversions_from_account_id_bank_accounts_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "currency_conversions_to_account_id_bank_accounts_id_fk": {
+          "name": "currency_conversions_to_account_id_bank_accounts_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.invites": {
+      "name": "invites",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_workspace_id_workspaces_id_fk": {
+          "name": "invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transaction_overrides": {
+      "name": "transaction_overrides",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tx_override_user_idx": {
+          "name": "tx_override_user_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_overrides_transaction_id_transactions_id_fk": {
+          "name": "transaction_overrides_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_overrides",
+          "tableTo": "transactions",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transactions": {
+      "name": "transactions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csv_upload_id": {
+          "name": "csv_upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_date": {
+          "name": "accounting_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_original": {
+          "name": "amount_original",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency_original": {
+          "name": "currency_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditor_name": {
+          "name": "creditor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debtor_name": {
+          "name": "debtor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_confidence": {
+          "name": "category_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override": {
+          "name": "category_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override_by_id": {
+          "name": "category_override_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_transfer": {
+          "name": "is_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transfer_counterpart_id": {
+          "name": "transfer_counterpart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_by_id": {
+          "name": "transfer_linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_at": {
+          "name": "transfer_linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_fx_candidate": {
+          "name": "is_fx_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "conversion_id": {
+          "name": "conversion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "my_portion": {
+          "name": "my_portion",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_order": {
+          "name": "original_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_opening_balance": {
+          "name": "is_opening_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "sync_source": {
+          "name": "sync_source",
+          "type": "sync_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_dedup_idx": {
+          "name": "transactions_dedup_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_accounting_date_idx": {
+          "name": "transactions_accounting_date_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accounting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_idx": {
+          "name": "transactions_transfer_idx",
+          "columns": [
+            {
+              "expression": "transfer_counterpart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_conversion_idx": {
+          "name": "transactions_conversion_idx",
+          "columns": [
+            {
+              "expression": "conversion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_bank_account_id_bank_accounts_id_fk": {
+          "name": "transactions_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_csv_upload_id_csv_uploads_id_fk": {
+          "name": "transactions_csv_upload_id_csv_uploads_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "csv_uploads",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "csv_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.workspaces": {
+      "name": "workspaces",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_status": {
+      "name": "account_status",
+      "schema": "public",
+      "values": [
+        "no_data",
+        "active"
+      ]
+    },
+    "public.account_visibility": {
+      "name": "account_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "stats_only",
+        "full"
+      ]
+    },
+    "public.conversion_confidence": {
+      "name": "conversion_confidence",
+      "schema": "public",
+      "values": [
+        "auto",
+        "confirmed",
+        "manual"
+      ]
+    },
+    "public.sync_source": {
+      "name": "sync_source",
+      "schema": "public",
+      "values": [
+        "csv_upload",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "posted",
+        "review"
+      ]
+    }
+  },
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1775393639876,
       "tag": "0005_magical_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1775404461321,
+      "tag": "0006_add_original_order_to_transactions",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"dependencies": {
 				"@types/papaparse": "^5.5.2",
 				"date-fns": "^4.1.0",
-				"papaparse": "^5.5.3"
+				"papaparse": "^5.5.3",
+				"xlsx": "^0.18.5"
 			},
 			"devDependencies": {
 				"@better-auth/cli": "~1.4.21",
@@ -3430,6 +3431,15 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/adler-32": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+			"integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3895,6 +3905,19 @@
 			],
 			"license": "CC-BY-4.0"
 		},
+		"node_modules/cfb": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+			"integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"adler-32": "~1.3.0",
+				"crc-32": "~1.2.0"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -3966,6 +3989,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/codepage": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+			"integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "12.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -4008,6 +4040,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -4797,6 +4841,15 @@
 			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/frac": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+			"integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=0.8"
+			}
 		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
@@ -6824,6 +6877,18 @@
 				"node": ">= 10.x"
 			}
 		},
+		"node_modules/ssf": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+			"integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"frac": "~1.1.2"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -8485,6 +8550,24 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/wmf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+			"integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/word": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+			"integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8516,6 +8599,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xlsx": {
+			"version": "0.18.5",
+			"resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+			"integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"adler-32": "~1.3.0",
+				"cfb": "~1.2.1",
+				"codepage": "~1.15.0",
+				"crc-32": "~1.2.1",
+				"ssf": "~0.11.2",
+				"wmf": "~1.0.1",
+				"word": "~0.3.0"
+			},
+			"bin": {
+				"xlsx": "bin/xlsx.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 	"dependencies": {
 		"@types/papaparse": "^5.5.2",
 		"date-fns": "^4.1.0",
-		"papaparse": "^5.5.3"
+		"papaparse": "^5.5.3",
+		"xlsx": "^0.18.5"
 	}
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -173,6 +173,10 @@ export const transactions = coreSchema.table(
 		// Used for dashboard "effective expense" calculation without a full Splitwise model.
 		myPortion: numeric('my_portion', { precision: 4, scale: 3 }),
 
+		// Original file row position (0-based, set on CSV import; null for manual/cron entries).
+		// Use for round-trip export ordering: ORDER BY accountingDate DESC, originalOrder ASC.
+		originalOrder: integer('original_order'),
+
 		// System flags
 		isOpeningBalance: boolean('is_opening_balance').default(false).notNull(),
 		// payerUserId references auth.user.id — enforced at app layer

--- a/src/lib/server/parsers/index.ts
+++ b/src/lib/server/parsers/index.ts
@@ -65,6 +65,24 @@ export function detectXLSXProfile(buffer: Buffer): string | null {
 	return null;
 }
 
+// ─── File direction detection ──────────────────────────────────────────────
+
+/**
+ * Detect whether the rows in a parsed file are in ascending or descending date order.
+ * Compares the first row's date against the last row's date.
+ * Returns 'unknown' when the file has fewer than 2 rows or all rows share the same date.
+ */
+export function detectFileDirection(
+	rows: import('./types.js').NormalizedTransaction[]
+): 'asc' | 'desc' | 'unknown' {
+	if (rows.length < 2) return 'unknown';
+	const first = rows[0].accountingDate;
+	const last = rows[rows.length - 1].accountingDate;
+	if (first < last) return 'asc';
+	if (first > last) return 'desc';
+	return 'unknown';
+}
+
 // ─── Per-profile post-normalise hooks ─────────────────────────────────────
 
 const POST_NORMALIZE: Partial<
@@ -125,7 +143,7 @@ export function parseCSV(csvText: string, profile: BankParserProfile): ParseResu
 			normalized = postNorm(normalized, raw);
 		}
 
-		rows.push(normalized);
+		rows.push({ ...normalized, sourceIndex: i });
 	}
 
 	// PapaParse parse-level errors
@@ -184,7 +202,7 @@ export function parseXLSX(buffer: Buffer, profile: BankParserProfile): ParseResu
 			normalized = postNorm(normalized, raw);
 		}
 
-		rows.push(normalized);
+		rows.push({ ...normalized, sourceIndex: i });
 	}
 
 	return { rows, skippedCount, errors };

--- a/src/lib/server/parsers/index.ts
+++ b/src/lib/server/parsers/index.ts
@@ -1,4 +1,5 @@
 import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
 import type { BankParserProfile, NormalizedTransaction } from './types.js';
 import { normalizeRow } from './normalizer.js';
 import {
@@ -6,11 +7,13 @@ import {
 	postNormalize as revolut_eu_postNormalize,
 	REVOLUT_EU_HEADER_FINGERPRINT
 } from './profiles/revolut_eu.js';
+import { bankinter_es, BANKINTER_ES_HEADER_FINGERPRINT } from './profiles/bankinter_es.js';
 
 // ─── Profile registry ──────────────────────────────────────────────────────
 
 const PROFILES: Record<string, BankParserProfile> = {
-	revolut_eu
+	revolut_eu,
+	bankinter_es
 };
 
 export function getProfile(bankProfileId: string): BankParserProfile | null {
@@ -30,6 +33,35 @@ export function getAllProfiles(): BankParserProfile[] {
 export function detectProfile(csvText: string): string | null {
 	const firstLine = csvText.split('\n')[0]?.trim() ?? '';
 	if (firstLine === REVOLUT_EU_HEADER_FINGERPRINT) return 'revolut_eu';
+	return null;
+}
+
+/**
+ * Attempt to detect the bank profile from an XLSX buffer.
+ * Reads only the first 10 rows (cheap) and matches the header row against known fingerprints.
+ * Returns the profileId string or null if no match.
+ */
+export function detectXLSXProfile(buffer: Buffer): string | null {
+	try {
+		const workbook = XLSX.read(buffer, { type: 'buffer', sheetRows: 10 });
+		const sheet = workbook.Sheets[workbook.SheetNames[0]];
+		const rows = XLSX.utils.sheet_to_json<string[]>(sheet, {
+			header: 1,
+			defval: '',
+			raw: false
+		}) as string[][];
+
+		// Bankinter: header at row index 8 (Excel row 9)
+		const bankinterHeader = rows[8];
+		if (
+			bankinterHeader &&
+			BANKINTER_ES_HEADER_FINGERPRINT.every((col, i) => bankinterHeader[i]?.trim() === col)
+		) {
+			return 'bankinter_es';
+		}
+	} catch {
+		// not a valid XLSX file
+	}
 	return null;
 }
 
@@ -105,10 +137,107 @@ export function parseCSV(csvText: string, profile: BankParserProfile): ParseResu
 }
 
 /**
+ * Parse an XLSX buffer using the given profile.
+ * Uses profile.skipRows as the 0-indexed row that becomes the header row.
+ * Returns normalised rows, count of skipped rows, and any parse errors.
+ */
+export function parseXLSX(buffer: Buffer, profile: BankParserProfile): ParseResult {
+	const workbook = XLSX.read(buffer, { type: 'buffer', cellDates: false });
+	const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+	// range: N → row index N becomes the header; rows N+1+ are data.
+	// raw: false → all cells coerced to strings, matching PapaParse behaviour.
+	// cellDates: false → dates remain as formatted strings (e.g. dd/MM/yyyy) for parseDateField().
+	const rawRows = XLSX.utils.sheet_to_json<Record<string, string>>(sheet, {
+		range: profile.skipRows,
+		defval: '',
+		raw: false
+	});
+
+	// Trim all header keys — SheetJS doesn't trim by default unlike PapaParse's transformHeader.
+	const rowsData = rawRows.map((row) =>
+		Object.fromEntries(Object.entries(row).map(([k, v]) => [k.trim(), v]))
+	);
+
+	const rows: NormalizedTransaction[] = [];
+	const errors: string[] = [];
+	let skippedCount = 0;
+	const postNorm = POST_NORMALIZE[profile.bankProfileId];
+
+	for (let i = 0; i < rowsData.length; i++) {
+		const raw = rowsData[i];
+		let normalized = normalizeRow(raw, profile);
+
+		if (!normalized) {
+			skippedCount++;
+			errors.push(`Row ${i + 1}: could not parse date "${raw[profile.dateColumn]}"`);
+			continue;
+		}
+
+		if (normalized.description === '') {
+			skippedCount++;
+			errors.push(`Row ${i + 1}: empty description — skipped`);
+			continue;
+		}
+
+		if (postNorm) {
+			normalized = postNorm(normalized, raw);
+		}
+
+		rows.push(normalized);
+	}
+
+	return { rows, skippedCount, errors };
+}
+
+// ─── File utilities ────────────────────────────────────────────────────────
+
+/**
  * Convert a file (from SvelteKit formData) to a UTF-8 string.
  * TODO: use chardet + iconv-lite for ISO-8859-1 profiles (e.g. CaixaBank).
  */
 export async function fileToText(file: File): Promise<string> {
 	const buffer = Buffer.from(await file.arrayBuffer());
 	return buffer.toString('utf8');
+}
+
+/**
+ * Convert a file (from SvelteKit formData) to a raw Buffer.
+ * Used for XLSX and other binary formats.
+ */
+export async function fileToBuffer(file: File): Promise<Buffer> {
+	return Buffer.from(await file.arrayBuffer());
+}
+
+// ─── Upload entry point ────────────────────────────────────────────────────
+
+/**
+ * Single entry point for all file uploads.
+ * Detects file type (csv / xlsx) → optionally detects bank profile → parses.
+ * Pass profileIdHint when the profile is already known (e.g. stored on the account record).
+ */
+export async function uploadAndParse(
+	file: File,
+	profileIdHint?: string | null
+): Promise<{ profileId: string; result: ParseResult }> {
+	const isXlsx =
+		file.name.endsWith('.xlsx') ||
+		file.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+	if (isXlsx) {
+		const buffer = await fileToBuffer(file);
+		const profileId = profileIdHint || detectXLSXProfile(buffer);
+		if (!profileId) throw new Error('Could not detect bank profile from XLSX');
+		const profile = getProfile(profileId);
+		if (!profile) throw new Error(`Unknown bank profile: ${profileId}`);
+		return { profileId, result: parseXLSX(buffer, profile) };
+	}
+
+	// Default: treat as CSV
+	const csvText = await fileToText(file);
+	const profileId = profileIdHint || detectProfile(csvText);
+	if (!profileId) throw new Error('Could not detect bank profile from CSV');
+	const profile = getProfile(profileId);
+	if (!profile) throw new Error(`Unknown bank profile: ${profileId}`);
+	return { profileId, result: parseCSV(csvText, profile) };
 }

--- a/src/lib/server/parsers/profiles/bankinter_es.ts
+++ b/src/lib/server/parsers/profiles/bankinter_es.ts
@@ -1,0 +1,38 @@
+import type { BankParserProfile } from '../types.js';
+
+export const bankinter_es: BankParserProfile = {
+	fileType: 'xlsx',
+	bankProfileId: 'bankinter_es',
+	displayName: 'Bankinter (ES)',
+	encoding: 'utf-8', // unused for XLSX
+	delimiter: '', // unused for XLSX
+	// Rows 0–7 are metadata/empty rows; row index 8 (Excel row 9) is the header row.
+	skipRows: 8,
+	dateColumn: 'Fecha contable',
+	dateFormat: 'dd/MM/yyyy',
+	valueDateColumn: 'Fecha valor',
+	amountColumn: 'Importe',
+	debitColumn: null,
+	creditColumn: null,
+	descriptionColumn: 'Descripción',
+	currencyColumn: 'Divisa',
+	localAmountColumn: null,
+	balanceColumn: 'Saldo',
+	statusColumn: null, // all exported rows are posted
+	typeColumn: null, // Bankinter exports do not include an operation type column
+	transferTypes: [],
+	fxCandidateTypes: []
+};
+
+/**
+ * Ordered column names from Excel row 9.
+ * Used by detectXLSXProfile() for auto-detection.
+ */
+export const BANKINTER_ES_HEADER_FINGERPRINT = [
+	'Fecha contable',
+	'Fecha valor',
+	'Descripción',
+	'Importe',
+	'Saldo',
+	'Divisa'
+];

--- a/src/lib/server/parsers/profiles/revolut_eu.ts
+++ b/src/lib/server/parsers/profiles/revolut_eu.ts
@@ -2,6 +2,7 @@ import type { BankParserProfile, NormalizedTransaction } from '../types.js';
 import { parseAmount } from '../normalizer.js';
 
 export const revolut_eu: BankParserProfile = {
+	fileType: 'csv',
 	bankProfileId: 'revolut_eu',
 	displayName: 'Revolut (EU)',
 	encoding: 'utf-8',

--- a/src/lib/server/parsers/types.ts
+++ b/src/lib/server/parsers/types.ts
@@ -34,6 +34,7 @@ export interface NormalizedTransaction {
 	rawType: string | null; // original type string from CSV
 	isTransferCandidate: boolean; // derived from rawType + profile.transferTypes
 	isFxCandidate: boolean; // derived from rawType + profile.fxCandidateTypes
+	sourceIndex: number; // 0-based position in original file (after skipRows); used for ordering
 }
 
 export type DedupAction = 'insert' | 'update_status' | 'update_desc' | 'skip' | 'review';

--- a/src/lib/server/parsers/types.ts
+++ b/src/lib/server/parsers/types.ts
@@ -1,4 +1,5 @@
 export interface BankParserProfile {
+	fileType: 'csv' | 'xlsx';
 	bankProfileId: string;
 	displayName: string;
 	encoding: string; // 'utf-8' | 'iso-8859-1'

--- a/src/routes/api/accounts/[id]/import/+server.ts
+++ b/src/routes/api/accounts/[id]/import/+server.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts, csvUploads, transactions } from '$lib/server/db/schema.js';
-import { uploadAndParse } from '$lib/server/parsers/index.js';
+import { uploadAndParse, detectFileDirection } from '$lib/server/parsers/index.js';
 import { classifyRow, applyStatusUpdate, applyDescUpdate } from '$lib/server/dedup.js';
 import { upsertOpeningBalance, refreshCurrentBalance } from '$lib/server/balance.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
@@ -101,7 +101,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 
 	// Persist the opening balance transaction if one was provided (or auto-computed from CSV)
 	if (openingBalance !== null && !isNaN(openingBalance) && rows.length > 0) {
-		const earliest = rows.reduce((a, b) => (a.accountingDate <= b.accountingDate ? a : b));
+		const direction = detectFileDirection(rows);
+		const earliest =
+			direction === 'desc'
+				? rows[rows.length - 1] // last file row = chronologically first
+				: rows.reduce((a, b) => (a.accountingDate <= b.accountingDate ? a : b));
 		await upsertOpeningBalance(account.id, openingBalance, earliest.accountingDate, locals.user.id);
 	}
 
@@ -146,6 +150,7 @@ function buildTxInsert(
 		description: row.description,
 		isTransfer: row.isTransferCandidate,
 		isFxCandidate: row.isFxCandidate,
+		originalOrder: row.sourceIndex,
 		status,
 		payerUserId,
 		syncSource: 'csv_upload'

--- a/src/routes/api/accounts/[id]/import/+server.ts
+++ b/src/routes/api/accounts/[id]/import/+server.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts, csvUploads, transactions } from '$lib/server/db/schema.js';
-import { getProfile, parseCSV, fileToText } from '$lib/server/parsers/index.js';
+import { uploadAndParse } from '$lib/server/parsers/index.js';
 import { classifyRow, applyStatusUpdate, applyDescUpdate } from '$lib/server/dedup.js';
 import { upsertOpeningBalance, refreshCurrentBalance } from '$lib/server/balance.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
@@ -30,17 +30,14 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	const openingBalanceRaw = formData.get('openingBalance') as string | null;
 	const openingBalance = openingBalanceRaw ? parseFloat(openingBalanceRaw.replace(',', '.')) : null;
 
-	const profile = getProfile(account.bankProfileId);
-	if (!profile) throw error(400, `No parser for bank profile: ${account.bankProfileId}`);
+	let rows: Awaited<ReturnType<typeof uploadAndParse>>['result']['rows'];
+	let skippedCount: number;
 
-	let csvText: string;
 	try {
-		csvText = await fileToText(file);
-	} catch {
-		throw error(400, 'Could not read file');
+		({ result: { rows, skippedCount } } = await uploadAndParse(file, account.bankProfileId));
+	} catch (e) {
+		throw error(400, e instanceof Error ? e.message : 'Could not parse file');
 	}
-
-	const { rows, skippedCount } = parseCSV(csvText, profile);
 
 	// Create the upload record first (transactions reference it)
 	const [upload] = await db
@@ -49,7 +46,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 			bankAccountId: account.id,
 			userId: locals.user.id,
 			filename: file.name,
-			bankProfileId: profile.bankProfileId,
+			bankProfileId: account.bankProfileId,
 			rowCount: rows.length + skippedCount,
 			importedCount: 0,
 			duplicateCount: 0,

--- a/src/routes/api/accounts/[id]/preview/+server.ts
+++ b/src/routes/api/accounts/[id]/preview/+server.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts } from '$lib/server/db/schema.js';
-import { uploadAndParse } from '$lib/server/parsers/index.js';
+import { uploadAndParse, detectFileDirection } from '$lib/server/parsers/index.js';
 
 // ─── POST /api/accounts/[id]/preview ──────────────────────────────────────────
 // Parse a CSV for the given bank account and return a preview — no DB writes.
@@ -37,17 +37,20 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		currency: r.currency
 	}));
 
-	// Derive balance metrics from the running balance column (if the profile provides one)
+	// Derive balance metrics from the running balance column (if the profile provides one).
+	// Use file direction (first vs last date) to identify the chronologically first/last row
+	// without relying on within-day ordering, which date sorting cannot resolve.
 	let openingBalance: number | null = null;
 	let closingBalance: number | null = null;
 	if (rows.length > 0) {
-		const earliest = rows.reduce((a, b) => (a.accountingDate <= b.accountingDate ? a : b));
-		const latest = rows.reduce((a, b) => (a.accountingDate >= b.accountingDate ? a : b));
-		if (earliest.runningBalance !== null) {
-			openingBalance = earliest.runningBalance - earliest.amount;
+		const direction = detectFileDirection(rows);
+		const firstRow = direction === 'desc' ? rows[rows.length - 1] : rows[0];
+		const lastRow = direction === 'desc' ? rows[0] : rows[rows.length - 1];
+		if (firstRow.runningBalance !== null) {
+			openingBalance = firstRow.runningBalance - firstRow.amount;
 		}
-		if (latest.runningBalance !== null) {
-			closingBalance = latest.runningBalance;
+		if (lastRow.runningBalance !== null) {
+			closingBalance = lastRow.runningBalance;
 		}
 	}
 

--- a/src/routes/api/accounts/[id]/preview/+server.ts
+++ b/src/routes/api/accounts/[id]/preview/+server.ts
@@ -3,7 +3,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts } from '$lib/server/db/schema.js';
-import { getProfile, parseCSV, fileToText } from '$lib/server/parsers/index.js';
+import { uploadAndParse } from '$lib/server/parsers/index.js';
 
 // ─── POST /api/accounts/[id]/preview ──────────────────────────────────────────
 // Parse a CSV for the given bank account and return a preview — no DB writes.
@@ -21,17 +21,14 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	const file = formData.get('file') as File | null;
 	if (!file) throw error(400, 'No file provided');
 
-	const profile = getProfile(account.bankProfileId);
-	if (!profile) throw error(400, `No parser for bank profile: ${account.bankProfileId}`);
+	let rows: Awaited<ReturnType<typeof uploadAndParse>>['result']['rows'];
+	let skippedCount: number;
 
-	let csvText: string;
 	try {
-		csvText = await fileToText(file);
-	} catch {
-		throw error(400, 'Could not read file');
+		({ result: { rows, skippedCount } } = await uploadAndParse(file, account.bankProfileId));
+	} catch (e) {
+		throw error(400, e instanceof Error ? e.message : 'Could not parse file');
 	}
-
-	const { rows, skippedCount } = parseCSV(csvText, profile);
 
 	const preview = rows.slice(0, 5).map((r) => ({
 		date: r.accountingDate.toISOString().split('T')[0],
@@ -56,7 +53,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 
 	return json({
 		filename: file.name,
-		profile: profile.bankProfileId,
+		profile: account.bankProfileId,
 		totalParsed: rows.length,
 		skippedCount,
 		preview,

--- a/src/routes/api/upload/+server.ts
+++ b/src/routes/api/upload/+server.ts
@@ -1,6 +1,6 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getProfile, detectProfile, parseCSV, fileToText } from '$lib/server/parsers/index.js';
+import { uploadAndParse } from '$lib/server/parsers/index.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
 import { classifyRow, applyStatusUpdate, applyDescUpdate } from '$lib/server/dedup.js';
 import {
@@ -32,18 +32,23 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const accessible = await getAccessibleAccountIds(locals.user.id);
 	if (!accessible.includes(bankAccountId)) throw error(403, 'Access denied to this account');
 
-	const csvText = await fileToText(file);
+	let profileId: string;
+	let rows: Awaited<ReturnType<typeof uploadAndParse>>['result']['rows'];
+	let skippedCount: number;
+	let errors: string[];
 
-	const profileId =
-		typeof profileIdParam === 'string' && profileIdParam ? profileIdParam : detectProfile(csvText);
+	try {
+		const parsed = await uploadAndParse(
+			file,
+			typeof profileIdParam === 'string' && profileIdParam ? profileIdParam : null
+		);
+		profileId = parsed.profileId;
+		({ rows, skippedCount, errors } = parsed.result);
+	} catch (e) {
+		throw error(400, e instanceof Error ? e.message : 'Could not parse file');
+	}
 
-	if (!profileId) throw error(400, 'Could not detect bank profile. Please select one manually.');
-
-	const profile = getProfile(profileId);
-	if (!profile) throw error(400, `Unknown bank profile: ${profileId}`);
-
-	// 1. Parse + normalise all rows
-	const { rows, skippedCount, errors } = parseCSV(csvText, profile);
+	// 1. Parse + normalise all rows (done above)
 	if (rows.length === 0) {
 		throw error(422, `No rows could be parsed. ${errors[0] ?? ''}`.trim());
 	}

--- a/src/routes/api/upload/preview/+server.ts
+++ b/src/routes/api/upload/preview/+server.ts
@@ -1,6 +1,6 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { getProfile, detectProfile, parseCSV, fileToText } from '$lib/server/parsers/index.js';
+import { uploadAndParse, getProfile } from '$lib/server/parsers/index.js';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user) throw error(401, 'Unauthorized');
@@ -13,18 +13,23 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!(file instanceof File)) throw error(400, 'Missing file');
 	if (file.size > 10 * 1024 * 1024) throw error(400, 'File too large (max 10 MB)');
 
-	const csvText = await fileToText(file);
+	let profileId: string;
+	let rows: Awaited<ReturnType<typeof uploadAndParse>>['result']['rows'];
+	let skippedCount: number;
+	let errors: string[];
 
-	// Resolve profile: use provided ID or auto-detect from header
-	const profileId =
-		typeof profileIdParam === 'string' && profileIdParam ? profileIdParam : detectProfile(csvText);
+	try {
+		const parsed = await uploadAndParse(
+			file,
+			typeof profileIdParam === 'string' && profileIdParam ? profileIdParam : null
+		);
+		profileId = parsed.profileId;
+		({ rows, skippedCount, errors } = parsed.result);
+	} catch (e) {
+		throw error(400, e instanceof Error ? e.message : 'Could not parse file');
+	}
 
-	if (!profileId) throw error(400, 'Could not detect bank profile. Please select one manually.');
-
-	const profile = getProfile(profileId);
-	if (!profile) throw error(400, `Unknown bank profile: ${profileId}`);
-
-	const { rows, skippedCount, errors } = parseCSV(csvText, profile);
+	const profile = getProfile(profileId)!;
 
 	if (rows.length === 0 && errors.length > 0) {
 		throw error(422, `Could not parse CSV: ${errors[0]}`);

--- a/tests/bankinter_parser/run.ts
+++ b/tests/bankinter_parser/run.ts
@@ -12,7 +12,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const dataDir = join(__dirname, 'data');
 
-const { parseXLSX, getProfile } = await import('../../src/lib/server/parsers/index.js');
+const { parseXLSX, getProfile, detectFileDirection } = await import(
+	'../../src/lib/server/parsers/index.js'
+);
 
 const profile = getProfile('bankinter_es');
 if (!profile) throw new Error('bankinter_es profile not found');
@@ -44,4 +46,23 @@ if (errors.length > 0) {
 	}
 }
 
+// Balance summary
+const direction = detectFileDirection(rows);
+const firstRow = direction === 'desc' ? rows[rows.length - 1] : rows[0];
+const lastRow = direction === 'desc' ? rows[0] : rows[rows.length - 1];
+const openingBalance =
+	firstRow?.runningBalance != null ? firstRow.runningBalance - firstRow.amount : null;
+const closingBalance = lastRow?.runningBalance ?? null;
+const periodBalance = rows.reduce((s, r) => s + r.amount, 0);
+
+console.log('\n──────────────────────────────────────────────────────────────────────────────');
+console.log(` File direction : ${direction}`);
+console.log(` Opening balance: ${openingBalance?.toFixed(2) ?? 'n/a'}`);
+console.log(` Period balance : ${periodBalance.toFixed(2)}`);
+console.log(` Closing balance: ${closingBalance?.toFixed(2) ?? 'n/a'}`);
+if (openingBalance !== null && closingBalance !== null) {
+	const check = openingBalance + periodBalance;
+	const ok = Math.abs(check - closingBalance) < 0.01;
+	console.log(` Reconciliation : ${check.toFixed(2)} (should equal closing) ${ok ? '✓' : '✗ MISMATCH'}`);
+}
 console.log();

--- a/tests/bankinter_parser/run.ts
+++ b/tests/bankinter_parser/run.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env tsx
+/**
+ * Bankinter ES parser smoke test.
+ * Reads the XLSX export, parses all rows, and prints a summary table.
+ *
+ * Run: npx tsx tests/bankinter_parser/run.ts
+ */
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dataDir = join(__dirname, 'data');
+
+const { parseXLSX, getProfile } = await import('../../src/lib/server/parsers/index.js');
+
+const profile = getProfile('bankinter_es');
+if (!profile) throw new Error('bankinter_es profile not found');
+
+const buffer = readFileSync(join(dataDir, 'bankinter_Q1-2026.xlsx'));
+
+const { rows, skippedCount, errors } = parseXLSX(buffer, profile);
+
+console.log('\n══════════════════════════════════════════════════════════════════════════════');
+console.log(' BANKINTER_Q1-2026.XLSX — parsed rows');
+console.log('══════════════════════════════════════════════════════════════════════════════');
+for (const r of rows) {
+	const date = r.accountingDate.toISOString().split('T')[0];
+	const amount = r.amount.toFixed(2).padStart(10);
+	const balance = r.runningBalance != null ? r.runningBalance.toFixed(2).padStart(10) : '          ';
+	const transfer = r.isTransferCandidate ? ' [transfer]' : '';
+	const fx = r.isFxCandidate ? ' [fx]' : '';
+	console.log(`  ${date}  ${amount}  bal: ${balance}  ${r.description}${transfer}${fx}`);
+}
+
+console.log(
+	`\n  Total parsed: ${rows.length}  |  Skipped: ${skippedCount}  |  Errors: ${errors.length}`
+);
+
+if (errors.length > 0) {
+	console.log('\n  Errors:');
+	for (const e of errors) {
+		console.log(`    ${e}`);
+	}
+}
+
+console.log();


### PR DESCRIPTION
Closes #5

## What's in this PR

### Bankinter ES parser
- New `bankinter_es` profile (`fileType: 'xlsx'`, `skipRows: 8`, `dd/MM/yyyy` dates, `Saldo` balance column)
- XLSX parsing via SheetJS — `parseXLSX()` reuses the existing `normalizeRow()` unchanged
- Auto-detection from header fingerprint (`detectXLSXProfile`)
- `uploadAndParse` wrapper: single entry point that dispatches to CSV or XLSX parser based on file extension
- Smoke test at `tests/bankinter_parser/run.ts` — parses `bankinter_Q1-2026.xlsx` and prints all 55 rows with balance summary

### Opening balance bug fix
**Problem:** the preview and import endpoints found the "earliest" row via `Array.reduce` over `accountingDate`. For Bankinter (descending file, `dd/MM/yyyy` — no time component), when the oldest day has multiple transactions the reduce picks the *first minimum-date row encountered* — i.e. the most recent transaction on that day — giving a wrong opening balance (e.g. `2776.95` instead of `3903.30`).

**Fix:** new `detectFileDirection(rows)` helper in `parsers/index.ts` — compares `rows[0].accountingDate` vs `rows[last].accountingDate` to return `'asc' | 'desc' | 'unknown'`. Both `preview/+server.ts` and `import/+server.ts` now use this to pick the correct boundary row instead of date-sorting:
- `desc` → `firstRow = rows[last]`, `lastRow = rows[0]`
- `asc` / `unknown` → `firstRow = rows[0]`, `lastRow = rows[last]` (with date-reduce fallback for `unknown`)

Reconciliation check confirms: `3903.30 + (−198.86) = 3704.44 ✓`

### Original transaction order
- Added `sourceIndex: number` to `NormalizedTransaction` — set to the 0-based loop index in both `parseCSV` and `parseXLSX`
- Added nullable `originalOrder: integer` column to `transactions` (migration `0006`)
- `buildTxInsert` stores `row.sourceIndex` as `originalOrder`
- Enables round-trip export ordering: `ORDER BY accountingDate DESC, originalOrder ASC` reproduces the original file sequence within each day

## Migration
`drizzle/migrations/0006_add_original_order_to_transactions.sql` — adds `original_order integer` (nullable) to `core.transactions`.