### PR TITLE
Transfer linking: auto-detect, surface in UI, and handle type-less bank profiles

### DIFF
--- a/features/pre-categorize.md
+++ b/features/pre-categorize.md
@@ -1,0 +1,138 @@
+# Feature: `preCategorize` — Description-based transfer detection ✓ DONE
+
+## Context
+
+Bankinter (and any future bank profile with `typeColumn: null`) never sets `isTransferCandidate: true`
+during normalization because there is no type column to read from. Since the upload pipeline inserts
+`isTransfer: row.isTransferCandidate` into the DB, those transactions never carry `isTransfer: true`.
+The transfer detector (`detectAndLinkTransfers`) queries `eq(transactions.isTransfer, true)` — so it
+completely skips Bankinter transactions, and transfers are never auto-detected or surfaced for manual
+linking.
+
+**Goal:** add a lightweight, regex-based `preCategorize()` step that flags transfer candidates by
+scanning the `description` field. No AI required — common Spanish bank transfer keywords are
+predictable enough for a first-pass heuristic. This is a stepping stone toward full AI tagging in
+Phase 5.
+
+---
+
+## Root cause trace
+
+```
+normalizeRow()
+  └─ isTransferCandidate = rawType !== null && profile.transferTypes.includes(rawType)
+       └─ bankinter_es: typeColumn = null → rawType = null → isTransferCandidate = ALWAYS false
+
+upload/+server.ts
+  └─ isTransfer: row.isTransferCandidate   ← always false for Bankinter
+
+detectAndLinkTransfers()
+  └─ WHERE isTransfer = true               ← skips all Bankinter rows
+```
+
+---
+
+## Critical files
+
+| File                                   | Role                                                                     |
+| -------------------------------------- | ------------------------------------------------------------------------ |
+| `src/lib/server/parsers/index.ts`      | `parseCSV` / `parseXLSX` — integration point                             |
+| `src/lib/server/parsers/normalizer.ts` | `normalizeRow` — sets `isTransferCandidate` from `typeColumn`            |
+| `src/lib/server/parsers/types.ts`      | `NormalizedTransaction` interface                                        |
+| `src/lib/server/transfer-detector.ts`  | Queries `isTransfer = true` — **unchanged**                              |
+| `src/routes/api/upload/+server.ts`     | Maps `row.isTransferCandidate → isTransfer` in DB insert — **unchanged** |
+| `tests/bankinter_parser/run.ts`        | Smoke test that already prints `[transfer]` flags                        |
+
+---
+
+## Implementation
+
+### 1. New file: `src/lib/server/parsers/pre-categorize.ts`
+
+```typescript
+import type { NormalizedTransaction } from './types.js';
+
+/**
+ * Lightweight heuristic pre-categorisation pass.
+ *
+ * For bank profiles that lack a `typeColumn` (e.g. bankinter_es), description-based
+ * pattern matching fills the role that the type column plays in profiles like revolut_eu.
+ *
+ * Only modifies `isTransferCandidate`; never overwrites a value already set to `true`
+ * by the type column. Returns a new object — never mutates the input.
+ */
+
+const TRANSFER_PATTERNS: RegExp[] = [
+	/\bTRANSF/i, // TRANSF, TRANSF., TRANSFERENCIA, TRANSFERENCIA EMITIDA/RECIBIDA …
+	/\bTRASPASO\b/i // Spanish term for inter-account savings transfer
+];
+
+export function preCategorize(row: NormalizedTransaction): NormalizedTransaction {
+	if (row.isTransferCandidate) return row; // already flagged via typeColumn — passthrough
+
+	const isTransfer = TRANSFER_PATTERNS.some((re) => re.test(row.description));
+	if (!isTransfer) return row;
+
+	return { ...row, isTransferCandidate: true };
+}
+```
+
+### 2. Edit `src/lib/server/parsers/index.ts`
+
+Add import at the top:
+
+```typescript
+import { preCategorize } from './pre-categorize.js';
+```
+
+Call it in **both** `parseCSV` and `parseXLSX`, after the `postNorm` block and before `rows.push(...)`:
+
+```typescript
+// before (in both functions):
+if (postNorm) {
+	normalized = postNorm(normalized, raw);
+}
+rows.push({ ...normalized, sourceIndex: i });
+
+// after:
+if (postNorm) {
+	normalized = postNorm(normalized, raw);
+}
+normalized = preCategorize(normalized); // ← add this line
+rows.push({ ...normalized, sourceIndex: i });
+```
+
+---
+
+## What does NOT change
+
+- `normalizer.ts` — stays pure; type-column logic untouched
+- `transfer-detector.ts` — unchanged; still queries `isTransfer = true`
+- `+server.ts` upload route — unchanged; still maps `row.isTransferCandidate → isTransfer`
+- `BankParserProfile` interface — no new fields needed
+- DB schema — no migration needed
+
+---
+
+## Extensibility
+
+`preCategorize` is intentionally minimal for now. In Phase 5, the same function can be extended to
+also fill the `category` field using AI or more advanced heuristics (e.g. RECIBO → `direct_debit`,
+NOMINA → `salary`). The function signature (`NormalizedTransaction → NormalizedTransaction`) is
+already compatible with that future expansion.
+
+---
+
+## Verification
+
+1. Run the bankinter smoke test — rows with TRANSF/TRASPASO in description will print `[transfer]`:
+
+   ```bash
+   npx tsx tests/bankinter_parser/run.ts
+   ```
+
+2. Upload a Bankinter XLSX with known transfers in the app. Confirm:
+   - `unresolvedTransfers` in the upload response is populated (or auto-linked if counterpart exists)
+   - Transactions show `isTransfer = true` in Drizzle Studio (`npm run db:studio`)
+
+3. Upload a Revolut CSV — verify existing `[transfer]` behaviour is unchanged (passthrough).

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -218,7 +218,7 @@
 </script>
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange}>
-	<Dialog.Content>
+	<Dialog.Content class="overflow-y-hidden">
 		<Dialog.Header>
 			<Dialog.Title>Import Transactions</Dialog.Title>
 		</Dialog.Header>
@@ -385,7 +385,7 @@
 
 			<!-- ── Step: Done ── -->
 		{:else if step === 'done' && importResult}
-			<div class="flex flex-col items-center gap-4 py-8 text-center">
+			<div class="flex flex-col items-center gap-4 text-center">
 				<div class="bg-success-100 flex h-14 w-14 items-center justify-center rounded-full">
 					<CheckCircle2 size={28} class="text-success-600" />
 				</div>
@@ -482,7 +482,7 @@
 
 			<!-- Transfer linking section -->
 			{#if importResult.unresolvedTransfers?.length > 0}
-				<div class="mt-4 w-full space-y-2">
+				<div class="my-4 w-full space-y-2 overflow-y-auto" style:max-height="min(40vh, 400px)">
 					{#each importResult.unresolvedTransfers as match (match.sourceId)}
 						{@const decision = transferDecisions[match.sourceId] ?? null}
 						{@const isLinking = transferLinking[match.sourceId] ?? false}
@@ -514,8 +514,17 @@
 						{:else if match.candidates.length === 0}
 							<!-- No counterpart found -->
 							<div class="rounded-lg border border-border bg-surface-sunken p-3 text-left">
-								<p class="text-xs font-medium text-text-primary">{match.sourceAccountName} · {match.sourceDescription}</p>
-								<p class="mt-0.5 text-[11px] text-text-tertiary">No matching transfer found — link manually from the transactions page if needed</p>
+								<div class="flex items-center justify-between gap-2">
+									<p class="truncate text-xs font-medium text-text-primary">{match.sourceAccountName} · {match.sourceDescription}</p>
+									<Amount value={match.sourceAmount} currency="EUR" size="sm" />
+								</div>
+								<div class="mt-1.5 flex items-center justify-between gap-2">
+									<p class="text-[11px] text-text-tertiary">No matching transfer found</p>
+									<button
+										class="text-[11px] text-text-tertiary underline underline-offset-2 hover:text-text-secondary"
+										onclick={() => (transferDecisions[match.sourceId] = 'skipped')}
+									>Skip</button>
+								</div>
 							</div>
 						{:else}
 							<!-- Multiple candidates — needs user choice -->
@@ -574,7 +583,7 @@
 		{/if}
 
 		<!-- Footer -->
-		<Dialog.Footer>
+		<Dialog.Footer class="sticky bottom-0 bg-surface pt-2">
 			{#if step === 'upload'}
 				<div></div>
 				<Button variant="outline" onclick={() => (open = false)}>Cancel</Button>

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
-	import { CheckCircle2, AlertCircle, Upload, ArrowRight, ArrowLeftRight } from '@lucide/svelte';
+	import { CheckCircle2, AlertCircle, Upload, ArrowRight, ArrowLeftRight, Link } from '@lucide/svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import Amount from '$lib/components/Amount.svelte';
@@ -54,16 +54,40 @@
 		toTransactionDescription: string;
 	};
 
+	type TransferCandidate = {
+		id: string;
+		accountingDate: string;
+		amount: number;
+		description: string;
+		bankAccountId: string;
+		accountName: string;
+		daysDiff: number;
+	};
+
+	type TransferMatch = {
+		sourceId: string;
+		sourceDescription: string;
+		sourceAmount: number;
+		sourceDate: string;
+		sourceAccountName: string;
+		candidateId: string | null;
+		candidates: TransferCandidate[];
+	};
+
 	type ImportResult = {
 		imported: number;
 		flagged: number;
 		statusUpdates: number;
 		duplicates: number;
 		detectedConversions: DetectedConversion[];
+		unresolvedTransfers: TransferMatch[];
 	};
 
 	let preview = $state<PreviewData | null>(null);
 	let importResult = $state<ImportResult | null>(null);
+	// Per-match state: sourceId → 'linked' | 'skipped' | selectedCandidateId | null (pending)
+	let transferDecisions = $state<Record<string, string | null>>({});
+	let transferLinking = $state<Record<string, boolean>>({});
 
 	function reset() {
 		step = 'upload';
@@ -74,6 +98,8 @@
 		balanceInput = '';
 		preview = null;
 		importResult = null;
+		transferDecisions = {};
+		transferLinking = {};
 	}
 
 	function handleOpenChange(v: boolean) {
@@ -162,6 +188,26 @@
 		} catch (e) {
 			err = e instanceof Error ? e.message : 'Import failed';
 			step = 'preview';
+		}
+	}
+
+	async function linkTransfer(sourceId: string, candidateId: string) {
+		transferLinking[sourceId] = true;
+		try {
+			const res = await fetch(`/api/transactions/${sourceId}/link-transfer`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ counterpartId: candidateId })
+			});
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({}));
+				throw new Error(data.message ?? 'Could not link transfer');
+			}
+			transferDecisions[sourceId] = 'linked';
+		} catch (e) {
+			err = e instanceof Error ? e.message : 'Could not link transfer';
+		} finally {
+			transferLinking[sourceId] = false;
 		}
 	}
 
@@ -416,6 +462,87 @@
 						{/each}
 					</div>
 				{/if}
+
+			<!-- Transfer linking section -->
+			{#if importResult.unresolvedTransfers?.length > 0}
+				<div class="mt-4 w-full space-y-2">
+					{#each importResult.unresolvedTransfers as match (match.sourceId)}
+						{@const decision = transferDecisions[match.sourceId] ?? null}
+						{@const isLinking = transferLinking[match.sourceId] ?? false}
+
+						{#if match.candidateId !== null}
+							<!-- Auto-linked -->
+							<div class="flex items-center gap-2 rounded-lg border border-border bg-surface-sunken px-3 py-2.5">
+								<Link size={13} class="shrink-0 text-success-600" />
+								<div class="min-w-0 flex-1">
+									<p class="text-xs font-medium text-text-primary">Transfer linked automatically</p>
+									<p class="truncate text-[11px] text-text-secondary">
+										{match.sourceAccountName} · {match.sourceDescription}
+										<span class="text-text-tertiary">→</span>
+										{match.candidates[0]?.accountName} · {match.candidates[0]?.description}
+									</p>
+								</div>
+							</div>
+						{:else if decision === 'linked'}
+							<!-- Just linked by user -->
+							<div class="flex items-center gap-2 rounded-lg border border-success-200 bg-success-50 px-3 py-2.5">
+								<CheckCircle2 size={13} class="shrink-0 text-success-600" />
+								<p class="text-xs font-medium text-success-700">Transfer linked</p>
+							</div>
+						{:else if decision === 'skipped'}
+							<!-- Dismissed -->
+							<div class="flex items-center gap-2 rounded-lg border border-border bg-surface-sunken px-3 py-2.5 opacity-50">
+								<p class="text-xs text-text-tertiary">Skipped — link manually from the transactions page</p>
+							</div>
+						{:else if match.candidates.length === 0}
+							<!-- No counterpart found -->
+							<div class="rounded-lg border border-border bg-surface-sunken p-3 text-left">
+								<p class="text-xs font-medium text-text-primary">{match.sourceAccountName} · {match.sourceDescription}</p>
+								<p class="mt-0.5 text-[11px] text-text-tertiary">No matching transfer found — link manually from the transactions page if needed</p>
+							</div>
+						{:else}
+							<!-- Multiple candidates — needs user choice -->
+							<div class="rounded-lg border border-border p-3 text-left">
+								<div class="mb-2 flex items-center gap-2">
+									<ArrowLeftRight size={13} class="text-text-tertiary" />
+									<div class="min-w-0">
+										<p class="text-xs font-semibold text-text-primary">{match.sourceAccountName}</p>
+										<p class="truncate text-[11px] text-text-secondary">{match.sourceDescription}</p>
+									</div>
+									<Amount value={match.sourceAmount} currency="EUR" size="sm" />
+								</div>
+								<p class="mb-1.5 text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">
+									Match with
+								</p>
+								<div class="space-y-1">
+									{#each match.candidates as candidate (candidate.id)}
+										<button
+											class="flex w-full items-center justify-between gap-2 rounded-md border border-border px-2.5 py-2 text-left transition-colors hover:border-primary-300 hover:bg-primary-50 disabled:opacity-50"
+											disabled={isLinking}
+											onclick={() => linkTransfer(match.sourceId, candidate.id)}
+										>
+											<div class="min-w-0">
+												<p class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">{candidate.accountName}</p>
+												<p class="truncate text-xs text-text-primary">{candidate.description}</p>
+												{#if candidate.daysDiff > 0}
+													<p class="text-[10px] text-text-tertiary">{candidate.daysDiff}d apart</p>
+												{/if}
+											</div>
+											<Amount value={candidate.amount} currency="EUR" size="sm" />
+										</button>
+									{/each}
+								</div>
+								<button
+									class="mt-2 text-[11px] text-text-tertiary underline underline-offset-2 hover:text-text-secondary"
+									onclick={() => (transferDecisions[match.sourceId] = 'skipped')}
+								>
+									Skip for now
+								</button>
+							</div>
+						{/if}
+					{/each}
+				</div>
+			{/if}
 			</div>
 		{/if}
 

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
-	import { CheckCircle2, AlertCircle, Upload, ArrowRight, ArrowLeftRight, Link } from '@lucide/svelte';
+	import {
+		CheckCircle2,
+		AlertCircle,
+		Upload,
+		ArrowRight,
+		ArrowLeftRight,
+		Link
+	} from '@lucide/svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import Amount from '$lib/components/Amount.svelte';
@@ -418,157 +425,185 @@
 					{/if}
 				</div>
 
-				<!-- Conversion confirmation cards -->
-				{#if importResult.detectedConversions?.length > 0}
-					<div class="mt-4 w-full space-y-2">
-						{#each importResult.detectedConversions as conv (conv.conversionId)}
-							<div class="rounded-lg border border-primary-200 bg-primary-50 p-4 text-left">
-								<div class="mb-3 flex items-center gap-2">
-									<ArrowLeftRight size={14} class="text-primary-500" />
-									<span class="text-xs font-semibold text-primary-700">Conversion detected</span>
-								</div>
-								<!-- From row -->
-								<div class="flex items-center justify-between gap-2">
-									<div class="min-w-0">
-										<p
-											class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
-										>
-											{conv.fromAccountName}
-										</p>
-										<p class="truncate text-xs text-text-secondary">
-											{conv.fromTransactionDescription}
-										</p>
+				<div class="max-h-[45vh] w-full overflow-y-auto">
+					<!-- Conversion confirmation cards -->
+					{#if importResult.detectedConversions?.length > 0}
+						<div class="mt-2 w-full space-y-2">
+							{#each importResult.detectedConversions as conv (conv.conversionId)}
+								<div class="rounded-lg border border-primary-200 bg-primary-50 p-4 text-left">
+									<div class="mb-3 flex items-center gap-2">
+										<ArrowLeftRight size={14} class="text-primary-500" />
+										<span class="text-xs font-semibold text-primary-700">Conversion detected</span>
 									</div>
-									<Amount value={-conv.fromAmount} currency="EUR" size="sm" />
-								</div>
-								<!-- Arrow -->
-								<div class="my-1.5 flex items-center gap-1.5 text-text-tertiary">
-									<div class="h-px flex-1 bg-primary-200"></div>
-									<ArrowRight size={12} class="text-primary-400" />
-									<div class="h-px flex-1 bg-primary-200"></div>
-								</div>
-								<!-- To row -->
-								<div class="flex items-center justify-between gap-2">
-									<div class="min-w-0">
-										<p
-											class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
-										>
-											{conv.toAccountName}
-										</p>
-										<p class="truncate text-xs text-text-secondary">
-											{conv.toTransactionDescription}
-										</p>
+									<!-- From row -->
+									<div class="flex items-center justify-between gap-2">
+										<div class="min-w-0">
+											<p
+												class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
+											>
+												{conv.fromAccountName}
+											</p>
+											<p class="truncate text-xs text-text-secondary">
+												{conv.fromTransactionDescription}
+											</p>
+										</div>
+										<Amount value={-conv.fromAmount} currency="EUR" size="sm" />
 									</div>
-									<Amount value={conv.toAmount} {currency} size="sm" />
-								</div>
-								<!-- Rate footer -->
-								<div
-									class="mt-3 flex items-center justify-between border-t border-primary-200 pt-2.5 text-xs text-text-secondary"
-								>
-									<span>
-										Rate: <span class="font-mono font-semibold text-text-primary">
-											{conv.exchangeRate.toFixed(4)}
-											{currency} / EUR
-										</span>
-									</span>
-									<span class="text-text-tertiary"
-										>Applies to {conv.affectedTxCount} transactions</span
+									<!-- Arrow -->
+									<div class="my-1.5 flex items-center gap-1.5 text-text-tertiary">
+										<div class="h-px flex-1 bg-primary-200"></div>
+										<ArrowRight size={12} class="text-primary-400" />
+										<div class="h-px flex-1 bg-primary-200"></div>
+									</div>
+									<!-- To row -->
+									<div class="flex items-center justify-between gap-2">
+										<div class="min-w-0">
+											<p
+												class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
+											>
+												{conv.toAccountName}
+											</p>
+											<p class="truncate text-xs text-text-secondary">
+												{conv.toTransactionDescription}
+											</p>
+										</div>
+										<Amount value={conv.toAmount} {currency} size="sm" />
+									</div>
+									<!-- Rate footer -->
+									<div
+										class="mt-3 flex items-center justify-between border-t border-primary-200 pt-2.5 text-xs text-text-secondary"
 									>
-								</div>
-							</div>
-						{/each}
-					</div>
-				{/if}
-
-			<!-- Transfer linking section -->
-			{#if importResult.unresolvedTransfers?.length > 0}
-				<div class="my-4 w-full space-y-2 overflow-y-auto" style:max-height="min(40vh, 400px)">
-					{#each importResult.unresolvedTransfers as match (match.sourceId)}
-						{@const decision = transferDecisions[match.sourceId] ?? null}
-						{@const isLinking = transferLinking[match.sourceId] ?? false}
-
-						{#if match.candidateId !== null}
-							<!-- Auto-linked -->
-							<div class="flex items-center gap-2 rounded-lg border border-border bg-surface-sunken px-3 py-2.5">
-								<Link size={13} class="shrink-0 text-success-600" />
-								<div class="min-w-0 flex-1">
-									<p class="text-xs font-medium text-text-primary">Transfer linked automatically</p>
-									<p class="truncate text-[11px] text-text-secondary">
-										{match.sourceAccountName} · {match.sourceDescription}
-										<span class="text-text-tertiary">→</span>
-										{match.candidates[0]?.accountName} · {match.candidates[0]?.description}
-									</p>
-								</div>
-							</div>
-						{:else if decision === 'linked'}
-							<!-- Just linked by user -->
-							<div class="flex items-center gap-2 rounded-lg border border-success-200 bg-success-50 px-3 py-2.5">
-								<CheckCircle2 size={13} class="shrink-0 text-success-600" />
-								<p class="text-xs font-medium text-success-700">Transfer linked</p>
-							</div>
-						{:else if decision === 'skipped'}
-							<!-- Dismissed -->
-							<div class="flex items-center gap-2 rounded-lg border border-border bg-surface-sunken px-3 py-2.5 opacity-50">
-								<p class="text-xs text-text-tertiary">Skipped — link manually from the transactions page</p>
-							</div>
-						{:else if match.candidates.length === 0}
-							<!-- No counterpart found -->
-							<div class="rounded-lg border border-border bg-surface-sunken p-3 text-left">
-								<div class="flex items-center justify-between gap-2">
-									<p class="truncate text-xs font-medium text-text-primary">{match.sourceAccountName} · {match.sourceDescription}</p>
-									<Amount value={match.sourceAmount} currency="EUR" size="sm" />
-								</div>
-								<div class="mt-1.5 flex items-center justify-between gap-2">
-									<p class="text-[11px] text-text-tertiary">No matching transfer found</p>
-									<button
-										class="text-[11px] text-text-tertiary underline underline-offset-2 hover:text-text-secondary"
-										onclick={() => (transferDecisions[match.sourceId] = 'skipped')}
-									>Skip</button>
-								</div>
-							</div>
-						{:else}
-							<!-- Multiple candidates — needs user choice -->
-							<div class="rounded-lg border border-border p-3 text-left">
-								<div class="mb-2 flex items-center gap-2">
-									<ArrowLeftRight size={13} class="text-text-tertiary" />
-									<div class="min-w-0">
-										<p class="text-xs font-semibold text-text-primary">{match.sourceAccountName}</p>
-										<p class="truncate text-[11px] text-text-secondary">{match.sourceDescription}</p>
-									</div>
-									<Amount value={match.sourceAmount} currency="EUR" size="sm" />
-								</div>
-								<p class="mb-1.5 text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">
-									Match with
-								</p>
-								<div class="space-y-1">
-									{#each match.candidates as candidate (candidate.id)}
-										<button
-											class="flex w-full items-center justify-between gap-2 rounded-md border border-border px-2.5 py-2 text-left transition-colors hover:border-primary-300 hover:bg-primary-50 disabled:opacity-50"
-											disabled={isLinking}
-											onclick={() => linkTransfer(match.sourceId, candidate.id)}
+										<span>
+											Rate: <span class="font-mono font-semibold text-text-primary">
+												{conv.exchangeRate.toFixed(4)}
+												{currency} / EUR
+											</span>
+										</span>
+										<span class="text-text-tertiary"
+											>Applies to {conv.affectedTxCount} transactions</span
 										>
-											<div class="min-w-0">
-												<p class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">{candidate.accountName}</p>
-												<p class="truncate text-xs text-text-primary">{candidate.description}</p>
-												{#if candidate.daysDiff > 0}
-													<p class="text-[10px] text-text-tertiary">{candidate.daysDiff}d apart</p>
-												{/if}
-											</div>
-											<Amount value={candidate.amount} currency="EUR" size="sm" />
-										</button>
-									{/each}
+									</div>
 								</div>
-								<button
-									class="mt-2 text-[11px] text-text-tertiary underline underline-offset-2 hover:text-text-secondary"
-									onclick={() => (transferDecisions[match.sourceId] = 'skipped')}
-								>
-									Skip for now
-								</button>
-							</div>
-						{/if}
-					{/each}
+							{/each}
+						</div>
+					{/if}
+
+					<!-- Transfer linking section -->
+					{#if importResult.unresolvedTransfers?.length > 0}
+						<div class="mt-4 w-full space-y-2">
+							{#each importResult.unresolvedTransfers as match (match.sourceId)}
+								{@const decision = transferDecisions[match.sourceId] ?? null}
+								{@const isLinking = transferLinking[match.sourceId] ?? false}
+
+								{#if match.candidateId !== null}
+									<!-- Auto-linked -->
+									<div
+										class="flex items-center gap-2 rounded-lg border border-border bg-surface-sunken px-3 py-2.5"
+									>
+										<Link size={13} class="shrink-0 text-success-600" />
+										<div class="min-w-0 flex-1">
+											<p class="text-xs font-medium text-text-primary">
+												Transfer linked automatically
+											</p>
+											<p class="truncate text-[11px] text-text-secondary">
+												{match.sourceAccountName} · {match.sourceDescription}
+												<span class="text-text-tertiary">→</span>
+												{match.candidates[0]?.accountName} · {match.candidates[0]?.description}
+											</p>
+										</div>
+									</div>
+								{:else if decision === 'linked'}
+									<!-- Just linked by user -->
+									<div
+										class="border-success-200 flex items-center gap-2 rounded-lg border bg-success-50 px-3 py-2.5"
+									>
+										<CheckCircle2 size={13} class="shrink-0 text-success-600" />
+										<p class="text-xs font-medium text-success-700">Transfer linked</p>
+									</div>
+								{:else if decision === 'skipped'}
+									<!-- Dismissed -->
+									<div
+										class="flex items-center gap-2 rounded-lg border border-border bg-surface-sunken px-3 py-2.5 opacity-50"
+									>
+										<p class="text-xs text-text-tertiary">
+											Skipped — link manually from the transactions page
+										</p>
+									</div>
+								{:else if match.candidates.length === 0}
+									<!-- No counterpart found -->
+									<div class="rounded-lg border border-border bg-surface-sunken p-3 text-left">
+										<div class="flex items-center justify-between gap-2">
+											<p class="truncate text-xs font-medium text-text-primary">
+												{match.sourceAccountName} · {match.sourceDescription}
+											</p>
+											<Amount value={match.sourceAmount} currency="EUR" size="sm" />
+										</div>
+										<div class="mt-1.5 flex items-center justify-between gap-2">
+											<p class="text-[11px] text-text-tertiary">No matching transfer found</p>
+											<button
+												class="text-[11px] text-text-tertiary underline underline-offset-2 hover:text-text-secondary"
+												onclick={() => (transferDecisions[match.sourceId] = 'skipped')}>Skip</button
+											>
+										</div>
+									</div>
+								{:else}
+									<!-- Multiple candidates — needs user choice -->
+									<div class="rounded-lg border border-border p-3 text-left">
+										<div class="mb-2 flex items-center gap-2">
+											<ArrowLeftRight size={13} class="text-text-tertiary" />
+											<div class="min-w-0">
+												<p class="text-xs font-semibold text-text-primary">
+													{match.sourceAccountName}
+												</p>
+												<p class="truncate text-[11px] text-text-secondary">
+													{match.sourceDescription}
+												</p>
+											</div>
+											<Amount value={match.sourceAmount} currency="EUR" size="sm" />
+										</div>
+										<p
+											class="mb-1.5 text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
+										>
+											Match with
+										</p>
+										<div class="space-y-1">
+											{#each match.candidates as candidate (candidate.id)}
+												<button
+													class="flex w-full items-center justify-between gap-2 rounded-md border border-border px-2.5 py-2 text-left transition-colors hover:border-primary-300 hover:bg-primary-50 disabled:opacity-50"
+													disabled={isLinking}
+													onclick={() => linkTransfer(match.sourceId, candidate.id)}
+												>
+													<div class="min-w-0">
+														<p
+															class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
+														>
+															{candidate.accountName}
+														</p>
+														<p class="truncate text-xs text-text-primary">
+															{candidate.description}
+														</p>
+														{#if candidate.daysDiff > 0}
+															<p class="text-[10px] text-text-tertiary">
+																{candidate.daysDiff}d apart
+															</p>
+														{/if}
+													</div>
+													<Amount value={candidate.amount} currency="EUR" size="sm" />
+												</button>
+											{/each}
+										</div>
+										<button
+											class="mt-2 text-[11px] text-text-tertiary underline underline-offset-2 hover:text-text-secondary"
+											onclick={() => (transferDecisions[match.sourceId] = 'skipped')}
+										>
+											Skip for now
+										</button>
+									</div>
+								{/if}
+							{/each}
+						</div>
+					{/if}
 				</div>
-			{/if}
 			</div>
 		{/if}
 

--- a/src/lib/server/parsers/index.ts
+++ b/src/lib/server/parsers/index.ts
@@ -2,6 +2,7 @@ import Papa from 'papaparse';
 import * as XLSX from 'xlsx';
 import type { BankParserProfile, NormalizedTransaction } from './types.js';
 import { normalizeRow } from './normalizer.js';
+import { preCategorize } from './pre-categorize.js';
 import {
 	revolut_eu,
 	postNormalize as revolut_eu_postNormalize,
@@ -143,6 +144,7 @@ export function parseCSV(csvText: string, profile: BankParserProfile): ParseResu
 			normalized = postNorm(normalized, raw);
 		}
 
+		normalized = preCategorize(normalized);
 		rows.push({ ...normalized, sourceIndex: i });
 	}
 
@@ -202,6 +204,7 @@ export function parseXLSX(buffer: Buffer, profile: BankParserProfile): ParseResu
 			normalized = postNorm(normalized, raw);
 		}
 
+		normalized = preCategorize(normalized);
 		rows.push({ ...normalized, sourceIndex: i });
 	}
 

--- a/src/lib/server/parsers/pre-categorize.ts
+++ b/src/lib/server/parsers/pre-categorize.ts
@@ -1,0 +1,25 @@
+import type { NormalizedTransaction } from './types.js';
+
+/**
+ * Lightweight heuristic pre-categorisation pass.
+ *
+ * For bank profiles that lack a `typeColumn` (e.g. bankinter_es), description-based
+ * pattern matching fills the role that the type column plays in profiles like revolut_eu.
+ *
+ * Only modifies `isTransferCandidate`; never overwrites a value already set to `true`
+ * by the type column. Returns a new object — never mutates the input.
+ */
+
+const TRANSFER_PATTERNS: RegExp[] = [
+	/\bTRANS/i, // TRANSF, TRANSF., TRANSFERENCIA, TRANSFERENCIA EMITIDA/RECIBIDA …
+	/\bTRASPASO\b/i // Spanish term for inter-account savings transfer
+];
+
+export function preCategorize(row: NormalizedTransaction): NormalizedTransaction {
+	if (row.isTransferCandidate) return row; // already flagged via typeColumn — passthrough
+
+	const isTransfer = TRANSFER_PATTERNS.some((re) => re.test(row.description));
+	if (!isTransfer) return row;
+
+	return { ...row, isTransferCandidate: true };
+}

--- a/src/lib/server/parsers/profiles/revolut_eu.ts
+++ b/src/lib/server/parsers/profiles/revolut_eu.ts
@@ -21,9 +21,10 @@ export const revolut_eu: BankParserProfile = {
 	balanceColumn: 'Saldo',
 	statusColumn: 'State',
 	typeColumn: 'Tipo',
-	// Only 'Transferir' rows are inter-account transfer candidates.
-	// 'Cambio' (currency exchange) is intentionally excluded from same-currency transfer matching.
-	transferTypes: ['Transferir'],
+	// 'Transferir' = outgoing/incoming peer transfers.
+	// 'Recargas' = bank top-ups (e.g. funding Revolut from a personal bank account) — also
+	// treated as transfer candidates so the counterpart in the source bank gets auto-linked.
+	transferTypes: ['Transferir', 'Recargas'],
 	// 'Cambio' marks a cross-currency exchange (e.g. EUR → SEK top-up).
 	fxCandidateTypes: ['Cambio']
 };

--- a/src/lib/server/transfer-detector.ts
+++ b/src/lib/server/transfer-detector.ts
@@ -1,7 +1,7 @@
 import { and, ne, eq, isNull, sql, inArray } from 'drizzle-orm';
 import { addDays, subDays } from 'date-fns';
 import { db } from './db/index.js';
-import { transactions } from './db/schema.js';
+import { bankAccounts, transactions } from './db/schema.js';
 
 function toDateStr(d: unknown): string {
 	const date = d instanceof Date ? d : new Date(d as string);
@@ -14,13 +14,18 @@ export interface TransferCandidate {
 	amount: number;
 	description: string;
 	bankAccountId: string;
+	accountName: string;
 	daysDiff: number;
 }
 
 export interface TransferMatch {
 	sourceId: string;
+	sourceDescription: string;
+	sourceAmount: number;
+	sourceDate: Date;
+	sourceAccountName: string;
 	candidateId: string | null; // null = no auto-link found
-	candidates: TransferCandidate[]; // empty when auto-linked
+	candidates: TransferCandidate[]; // populated for auto-linked (1 item) and unresolved (1+ items)
 }
 
 /**
@@ -44,8 +49,16 @@ export async function detectAndLinkTransfers(
 	if (newTransactionIds.length === 0 || accessibleAccountIds.length === 0) return [];
 
 	const sources = await db
-		.select()
+		.select({
+			id: transactions.id,
+			accountingDate: transactions.accountingDate,
+			amount: transactions.amount,
+			description: transactions.description,
+			bankAccountId: transactions.bankAccountId,
+			accountName: bankAccounts.displayName
+		})
 		.from(transactions)
+		.innerJoin(bankAccounts, eq(transactions.bankAccountId, bankAccounts.id))
 		.where(
 			and(
 				inArray(transactions.id, newTransactionIds),
@@ -72,11 +85,13 @@ export async function detectAndLinkTransfers(
 				amount: transactions.amount,
 				description: transactions.description,
 				bankAccountId: transactions.bankAccountId,
+				accountName: bankAccounts.displayName,
 				daysDiff: sql<number>`ABS(EXTRACT(DAY FROM (
 					${transactions.accountingDate} - ${sourceDateStr}::date
 				)))`
 			})
 			.from(transactions)
+			.innerJoin(bankAccounts, eq(transactions.bankAccountId, bankAccounts.id))
 			.where(
 				and(
 					ne(transactions.bankAccountId, source.bankAccountId),
@@ -94,22 +109,29 @@ export async function detectAndLinkTransfers(
 			)
 			.limit(5);
 
+		const mappedCandidates = candidates.map((c) => ({
+			id: c.id,
+			accountingDate: c.accountingDate as unknown as Date,
+			amount: parseFloat(c.amount as unknown as string),
+			description: c.description,
+			bankAccountId: c.bankAccountId,
+			accountName: c.accountName,
+			daysDiff: c.daysDiff
+		}));
+
+		const baseMatch = {
+			sourceId: source.id,
+			sourceDescription: source.description,
+			sourceAmount: parseFloat(source.amount as unknown as string),
+			sourceDate: sourceDate,
+			sourceAccountName: source.accountName
+		};
+
 		if (candidates.length === 1) {
 			await linkPair(source.id, candidates[0].id, linkedById);
-			results.push({ sourceId: source.id, candidateId: candidates[0].id, candidates: [] });
+			results.push({ ...baseMatch, candidateId: candidates[0].id, candidates: mappedCandidates });
 		} else {
-			results.push({
-				sourceId: source.id,
-				candidateId: null,
-				candidates: candidates.map((c) => ({
-					id: c.id,
-					accountingDate: c.accountingDate as unknown as Date,
-					amount: parseFloat(c.amount as unknown as string),
-					description: c.description,
-					bankAccountId: c.bankAccountId,
-					daysDiff: c.daysDiff
-				}))
-			});
+			results.push({ ...baseMatch, candidateId: null, candidates: mappedCandidates });
 		}
 	}
 

--- a/src/routes/api/transactions/[id]/link-transfer/+server.ts
+++ b/src/routes/api/transactions/[id]/link-transfer/+server.ts
@@ -1,0 +1,48 @@
+import { error, json } from '@sveltejs/kit';
+import { eq, inArray } from 'drizzle-orm';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { transactions } from '$lib/server/db/schema.js';
+import { getAccessibleAccountIds } from '$lib/server/db/access.js';
+import { linkPair } from '$lib/server/transfer-detector.js';
+
+// ─── POST /api/transactions/[id]/link-transfer ────────────────────────────────
+// Manually link two transactions as a transfer pair.
+
+export const POST: RequestHandler = async ({ params, request, locals }) => {
+	if (!locals.user) throw error(401, 'Unauthorized');
+
+	const body = await request.json();
+	const counterpartId = body?.counterpartId;
+	if (!counterpartId || typeof counterpartId !== 'string') {
+		throw error(400, 'counterpartId is required');
+	}
+
+	const accessibleIds = await getAccessibleAccountIds(locals.user.id);
+	if (accessibleIds.length === 0) throw error(403, 'Forbidden');
+
+	const [source, counterpart] = await Promise.all([
+		db.query.transactions.findFirst({
+			where: eq(transactions.id, params.id),
+			columns: { id: true, bankAccountId: true, transferCounterpartId: true }
+		}),
+		db.query.transactions.findFirst({
+			where: eq(transactions.id, counterpartId),
+			columns: { id: true, bankAccountId: true, transferCounterpartId: true }
+		})
+	]);
+
+	if (!source || !counterpart) throw error(404, 'Transaction not found');
+
+	// Both transactions must be in accounts the user can access
+	const ids = [source.bankAccountId, counterpart.bankAccountId];
+	if (!ids.every((id) => accessibleIds.includes(id))) throw error(403, 'Forbidden');
+
+	if (source.transferCounterpartId || counterpart.transferCounterpartId) {
+		throw error(409, 'One or both transactions are already linked');
+	}
+
+	await linkPair(params.id, counterpartId, locals.user.id);
+
+	return json({ ok: true });
+};

--- a/tests/transfer_counterpart/run.ts
+++ b/tests/transfer_counterpart/run.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env tsx
+/**
+ * Transfer counterpart dry-run test.
+ *
+ * Parses two files (Bankinter XLSX + Revolut CSV) and verifies that transfer
+ * candidates in each file have matching counterparts in the other file using
+ * the same criteria the DB-backed detector uses:
+ *   - Opposite sign
+ *   - Same absolute amount
+ *   - Booking date within ±3 days
+ *
+ * Run: npx tsx tests/transfer_counterpart/run.ts
+ */
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import type { NormalizedTransaction } from '../../src/lib/server/parsers/types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dataDir = join(__dirname, 'data');
+
+const { parseXLSX, parseCSV, getProfile } = await import(
+	'../../src/lib/server/parsers/index.js'
+);
+
+// ── Parse both files ──────────────────────────────────────────────────────────
+
+const bankinterProfile = getProfile('bankinter_es');
+if (!bankinterProfile) throw new Error('bankinter_es profile not found');
+const bankinterBuffer = readFileSync(join(dataDir, 'bankinter_Q1-2026.xlsx'));
+const { rows: bankinterRows } = parseXLSX(bankinterBuffer, bankinterProfile);
+
+const revolutProfile = getProfile('revolut_eu');
+if (!revolutProfile) throw new Error('revolut_eu profile not found');
+const revolutCsvText = readFileSync(join(dataDir, 'revolut_2.csv'), 'utf-8');
+const { rows: revolutRows } = parseCSV(revolutCsvText, revolutProfile);
+
+// ── Matching helpers ──────────────────────────────────────────────────────────
+
+const MS_PER_DAY = 86_400_000;
+
+function daysDiff(a: Date, b: Date): number {
+	return Math.abs(a.getTime() - b.getTime()) / MS_PER_DAY;
+}
+
+function fmt(n: number): string {
+	return (n >= 0 ? '+' : '') + n.toFixed(2);
+}
+
+function findCounterparts(
+	source: NormalizedTransaction,
+	pool: NormalizedTransaction[]
+): NormalizedTransaction[] {
+	return pool.filter(
+		(c) =>
+			Math.abs(c.amount) === Math.abs(source.amount) &&
+			Math.sign(c.amount) !== Math.sign(source.amount) &&
+			daysDiff(source.accountingDate, c.accountingDate) <= 3
+	);
+}
+
+// ── Run matching ──────────────────────────────────────────────────────────────
+
+const bankinterTransfers = bankinterRows.filter((r) => r.isTransferCandidate);
+const revolutTransfers = revolutRows.filter((r) => r.isTransferCandidate);
+
+console.log('\n══════════════════════════════════════════════════════════════════════════════');
+console.log(' TRANSFER COUNTERPART DRY-RUN');
+console.log('══════════════════════════════════════════════════════════════════════════════');
+console.log(`  Bankinter transfer candidates : ${bankinterTransfers.length}`);
+console.log(`  Revolut   transfer candidates : ${revolutTransfers.length}`);
+
+// ── Section 1: Bankinter → Revolut ───────────────────────────────────────────
+
+console.log('\n──────────────────────────────────────────────────────────────────────────────');
+console.log(' Bankinter transfer candidates  →  search in Revolut (all rows)');
+console.log('──────────────────────────────────────────────────────────────────────────────');
+
+let bankinterMatched = 0;
+let bankinterUnmatched = 0;
+
+for (const r of bankinterTransfers) {
+	const date = r.accountingDate.toISOString().split('T')[0];
+	const counterparts = findCounterparts(r, revolutRows);
+
+	if (counterparts.length > 0) {
+		bankinterMatched++;
+		console.log(`  ✓  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}`);
+		for (const cp of counterparts) {
+			const cpDate = cp.accountingDate.toISOString().split('T')[0];
+			const diff = daysDiff(r.accountingDate, cp.accountingDate);
+			console.log(
+				`       ↳  ${cpDate}  ${fmt(cp.amount).padStart(10)}  ${cp.description}${diff > 0 ? `  (${diff}d apart)` : ''}`
+			);
+		}
+	} else {
+		bankinterUnmatched++;
+		console.log(`  ✗  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}`);
+	}
+}
+
+// ── Section 2: Revolut → Bankinter ───────────────────────────────────────────
+
+console.log('\n──────────────────────────────────────────────────────────────────────────────');
+console.log(' Revolut transfer candidates  →  search in Bankinter (all rows)');
+console.log('──────────────────────────────────────────────────────────────────────────────');
+
+let revolutMatched = 0;
+let revolutUnmatched = 0;
+
+for (const r of revolutTransfers) {
+	const date = r.accountingDate.toISOString().split('T')[0];
+	const counterparts = findCounterparts(r, bankinterRows);
+
+	if (counterparts.length > 0) {
+		revolutMatched++;
+		console.log(`  ✓  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}`);
+		for (const cp of counterparts) {
+			const cpDate = cp.accountingDate.toISOString().split('T')[0];
+			const diff = daysDiff(r.accountingDate, cp.accountingDate);
+			console.log(
+				`       ↳  ${cpDate}  ${fmt(cp.amount).padStart(10)}  ${cp.description}${diff > 0 ? `  (${diff}d apart)` : ''}`
+			);
+		}
+	} else {
+		revolutUnmatched++;
+		console.log(`  ✗  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}`);
+	}
+}
+
+// ── Section 3: Revolut top-ups (Recargas) coverage check ────────────────────
+// 'Recargas' (bank top-ups) are included in revolut_eu.transferTypes so they are
+// flagged as isTransferCandidate and will be searched as sources when Revolut is uploaded.
+
+const revolutRecargas = revolutRows.filter((r) => r.rawType === 'Recargas');
+
+if (revolutRecargas.length > 0) {
+	const allFlagged = revolutRecargas.every((r) => r.isTransferCandidate);
+	console.log('\n──────────────────────────────────────────────────────────────────────────────');
+	console.log(
+		` Revolut "Recargas" (top-ups) — isTransferCandidate: ${allFlagged ? '✓ all flagged' : '✗ some NOT flagged'}`
+	);
+	console.log('──────────────────────────────────────────────────────────────────────────────');
+
+	for (const r of revolutRecargas) {
+		const date = r.accountingDate.toISOString().split('T')[0];
+		const counterparts = findCounterparts(r, bankinterRows);
+		const flagged = r.isTransferCandidate ? '✓' : '✗';
+
+		if (counterparts.length > 0) {
+			console.log(`  ${flagged}  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}  (has bankinter match)`);
+			for (const cp of counterparts) {
+				const cpDate = cp.accountingDate.toISOString().split('T')[0];
+				const diff = daysDiff(r.accountingDate, cp.accountingDate);
+				console.log(
+					`       ↳  ${cpDate}  ${fmt(cp.amount).padStart(10)}  ${cp.description}${diff > 0 ? `  (${diff}d apart)` : ''}`
+				);
+			}
+		} else {
+			console.log(`  ${flagged}  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}  (no bankinter match)`);
+		}
+	}
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log('\n══════════════════════════════════════════════════════════════════════════════');
+console.log(' SUMMARY');
+console.log('──────────────────────────────────────────────────────────────────────────────');
+console.log(`  Bankinter → Revolut : ${bankinterMatched} matched / ${bankinterUnmatched} unmatched`);
+console.log(`  Revolut → Bankinter : ${revolutMatched} matched / ${revolutUnmatched} unmatched`);
+if (revolutRecargas.length > 0) {
+	const recargasWithMatch = revolutRecargas.filter(
+		(r) => findCounterparts(r, bankinterRows).length > 0
+	).length;
+	console.log(`  Recargas (matches) : ${recargasWithMatch}/${revolutRecargas.length} have a bankinter counterpart`);
+	const recargasFlagged = revolutRecargas.filter((r) => r.isTransferCandidate).length;
+	console.log(`  Recargas flagged   : ${recargasFlagged}/${revolutRecargas.length} are isTransferCandidate`);
+}
+console.log();

--- a/tests/transfer_counterpart/run.ts
+++ b/tests/transfer_counterpart/run.ts
@@ -19,9 +19,7 @@ import type { NormalizedTransaction } from '../../src/lib/server/parsers/types.j
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const dataDir = join(__dirname, 'data');
 
-const { parseXLSX, parseCSV, getProfile } = await import(
-	'../../src/lib/server/parsers/index.js'
-);
+const { parseXLSX, parseCSV, getProfile } = await import('../../src/lib/server/parsers/index.js');
 
 // ── Parse both files ──────────────────────────────────────────────────────────
 
@@ -148,7 +146,9 @@ if (revolutRecargas.length > 0) {
 		const flagged = r.isTransferCandidate ? '✓' : '✗';
 
 		if (counterparts.length > 0) {
-			console.log(`  ${flagged}  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}  (has bankinter match)`);
+			console.log(
+				`  ${flagged}  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}  (has bankinter match)`
+			);
 			for (const cp of counterparts) {
 				const cpDate = cp.accountingDate.toISOString().split('T')[0];
 				const diff = daysDiff(r.accountingDate, cp.accountingDate);
@@ -157,7 +157,9 @@ if (revolutRecargas.length > 0) {
 				);
 			}
 		} else {
-			console.log(`  ${flagged}  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}  (no bankinter match)`);
+			console.log(
+				`  ${flagged}  ${date}  ${fmt(r.amount).padStart(10)}  ${r.description}  (no bankinter match)`
+			);
 		}
 	}
 }
@@ -167,14 +169,20 @@ if (revolutRecargas.length > 0) {
 console.log('\n══════════════════════════════════════════════════════════════════════════════');
 console.log(' SUMMARY');
 console.log('──────────────────────────────────────────────────────────────────────────────');
-console.log(`  Bankinter → Revolut : ${bankinterMatched} matched / ${bankinterUnmatched} unmatched`);
+console.log(
+	`  Bankinter → Revolut : ${bankinterMatched} matched / ${bankinterUnmatched} unmatched`
+);
 console.log(`  Revolut → Bankinter : ${revolutMatched} matched / ${revolutUnmatched} unmatched`);
 if (revolutRecargas.length > 0) {
 	const recargasWithMatch = revolutRecargas.filter(
 		(r) => findCounterparts(r, bankinterRows).length > 0
 	).length;
-	console.log(`  Recargas (matches) : ${recargasWithMatch}/${revolutRecargas.length} have a bankinter counterpart`);
+	console.log(
+		`  Recargas (matches) : ${recargasWithMatch}/${revolutRecargas.length} have a bankinter counterpart`
+	);
 	const recargasFlagged = revolutRecargas.filter((r) => r.isTransferCandidate).length;
-	console.log(`  Recargas flagged   : ${recargasFlagged}/${revolutRecargas.length} are isTransferCandidate`);
+	console.log(
+		`  Recargas flagged   : ${recargasFlagged}/${revolutRecargas.length} are isTransferCandidate`
+	);
 }
 console.log();


### PR DESCRIPTION
## Summary

Closes #28, closes #9.

This PR completes the transfer-linking feature end-to-end:

- **Backend detection** — `transfer-detector.ts` now joins `bankAccounts` so each candidate carries its account name, and source transaction details (`sourceDescription`, `sourceAmount`, `sourceDate`, `sourceAccountName`) are populated in `TransferMatch` — giving the frontend everything it needs without a second request.
- **Manual link API** — new `POST /api/transactions/[id]/link-transfer` endpoint validates both sides, checks neither is already linked, and calls the existing `linkPair()`.
- **`preCategorize` pass** — banks without a `typeColumn` (e.g. Bankinter) never produced `isTransfer: true`, so the detector silently skipped all their transactions. A new `preCategorize()` step (`src/lib/server/parsers/pre-categorize.ts`) runs after normalisation and flags rows whose description matches transfer keywords (`TRANSF*`, `TRASPASO`) — filling the same role that `typeColumn` + `transferTypes` plays for Revolut.
- **Revolut `Recargas` type** — bank top-ups (`Recargas`) are now included in `revolut_eu.transferTypes`. Previously, when Revolut was uploaded *after* Bankinter, the `+400`/`+300` top-up rows were not flagged as transfer sources, causing the bankinter outgoing transfers to remain permanently unresolved. They are now auto-linked regardless of upload order.
- **Import dialog** — the Done step now renders a scrollable transfer-linking section (fixed header + footer, list scrolls independently):
  - Auto-linked pairs shown as a confirmation pill.
  - Unresolved with candidates: selectable card list; clicking a candidate calls the link API and collapses to "linked".
  - Unresolved with no candidates: shows the transaction amount alongside the description, plus a Skip button to dismiss — previously there was no amount and no action.
  - Footer (`Done` button) is now `sticky bottom-0` so it remains visible regardless of list length.

## Tests

A dry-run smoke test (`tests/transfer_counterpart/run.ts`) validates transfer-counterpart detection in-memory against two real export files (one Bankinter XLSX, one Revolut CSV) without touching the database. It confirms:

- Both files contain matching counterpart pairs (same absolute amount, opposite sign, within ±3 days).
- The `Recargas` top-ups are correctly flagged as `isTransferCandidate` after the profile change.
- Revolut `Transferir` rows that go to third parties (not the user's own accounts) correctly show no bankinter counterpart, which is expected.

Run with: `npx tsx tests/transfer_counterpart/run.ts`