### PR TITLE
Category management + inline category picker

### DIFF
--- a/drizzle/migrations/0007_add_category_parent.sql
+++ b/drizzle/migrations/0007_add_category_parent.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "core"."categories" ADD COLUMN "parent_id" text;
+ALTER TABLE "core"."categories"
+  ADD CONSTRAINT "categories_parent_id_fk"
+  FOREIGN KEY ("parent_id") REFERENCES "core"."categories"("id")
+  ON DELETE SET NULL ON UPDATE NO ACTION;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775404461321,
       "tag": "0006_add_original_order_to_transactions",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1744027200000,
+      "tag": "0007_add_category_parent",
+      "breakpoints": true
     }
   ]
 }

--- a/features/multi-currency-accounts.md
+++ b/features/multi-currency-accounts.md
@@ -24,8 +24,8 @@ Add a `currency` column defaulting to `EUR`. This is the native currency of the 
 
 ```ts
 export const accounts = pgTable('accounts', {
-  // ... existing columns
-  currency: varchar('currency', { length: 3 }).notNull().default('EUR'),
+	// ... existing columns
+	currency: varchar('currency', { length: 3 }).notNull().default('EUR')
 });
 ```
 
@@ -46,21 +46,21 @@ Tracks each funding event: a user converts money from one currency account to an
 
 ```ts
 export const currencyConversions = pgTable('currency_conversions', {
-  id:               uuid('id').primaryKey().defaultRandom(),
-  workspaceId:      uuid('workspace_id').notNull(),
-  fromAccountId:    uuid('from_account_id').notNull(), // e.g. Revolut EUR
-  toAccountId:      uuid('to_account_id').notNull(),   // e.g. Revolut SEK
-  fromAmount:       numeric('from_amount',   { precision: 18, scale: 4 }).notNull(), // 200.0000
-  toAmount:         numeric('to_amount',     { precision: 18, scale: 4 }).notNull(), // 2182.0000
-  exchangeRate:     numeric('exchange_rate', { precision: 14, scale: 6 }).notNull(), // 10.910000
-  effectiveFrom:    timestamp('effective_from').notNull(), // date of the funding transaction
-  confidence:       varchar('confidence', { length: 20 }).notNull().default('auto'),
-  // 'auto'     → derived from matched transfer pair
-  // 'confirmed' → user confirmed the auto-detected rate
-  // 'manual'   → user entered the rate by hand
-  fromTransactionId: uuid('from_transaction_id'), // FK to the -200 EUR transaction
-  toTransactionId:   uuid('to_transaction_id'),   // FK to the +2182 SEK transaction
-  createdAt:        timestamp('created_at').notNull().defaultNow(),
+	id: uuid('id').primaryKey().defaultRandom(),
+	workspaceId: uuid('workspace_id').notNull(),
+	fromAccountId: uuid('from_account_id').notNull(), // e.g. Revolut EUR
+	toAccountId: uuid('to_account_id').notNull(), // e.g. Revolut SEK
+	fromAmount: numeric('from_amount', { precision: 18, scale: 4 }).notNull(), // 200.0000
+	toAmount: numeric('to_amount', { precision: 18, scale: 4 }).notNull(), // 2182.0000
+	exchangeRate: numeric('exchange_rate', { precision: 14, scale: 6 }).notNull(), // 10.910000
+	effectiveFrom: timestamp('effective_from').notNull(), // date of the funding transaction
+	confidence: varchar('confidence', { length: 20 }).notNull().default('auto'),
+	// 'auto'     → derived from matched transfer pair
+	// 'confirmed' → user confirmed the auto-detected rate
+	// 'manual'   → user entered the rate by hand
+	fromTransactionId: uuid('from_transaction_id'), // FK to the -200 EUR transaction
+	toTransactionId: uuid('to_transaction_id'), // FK to the +2182 SEK transaction
+	createdAt: timestamp('created_at').notNull().defaultNow()
 });
 ```
 
@@ -72,22 +72,22 @@ Add FX columns. All are nullable — EUR-native transactions will have them as `
 
 ```ts
 export const transactions = pgTable('transactions', {
-  // ... existing columns:
-  // id, workspaceId, accountId, amount, balance, date, description, ...
+	// ... existing columns:
+	// id, workspaceId, accountId, amount, balance, date, description, ...
 
-  // FX fields
-  nativeCurrency:  varchar('native_currency', { length: 3 }),
-  // Redundant with account.currency but useful for denormalized queries.
-  // Always matches the account's currency at time of import.
+	// FX fields
+	nativeCurrency: varchar('native_currency', { length: 3 }),
+	// Redundant with account.currency but useful for denormalized queries.
+	// Always matches the account's currency at time of import.
 
-  eurAmount:       numeric('eur_amount',    { precision: 18, scale: 4 }),
-  // The EUR equivalent of this transaction. Null if unresolved.
+	eurAmount: numeric('eur_amount', { precision: 18, scale: 4 }),
+	// The EUR equivalent of this transaction. Null if unresolved.
 
-  exchangeRate:    numeric('exchange_rate', { precision: 14, scale: 6 }),
-  // The locked rate used to compute eurAmount.
+	exchangeRate: numeric('exchange_rate', { precision: 14, scale: 6 }),
+	// The locked rate used to compute eurAmount.
 
-  conversionId:    uuid('conversion_id'),
-  // FK to currency_conversions. Null if unresolved or EUR-native.
+	conversionId: uuid('conversion_id')
+	// FK to currency_conversions. Null if unresolved or EUR-native.
 });
 ```
 
@@ -300,13 +300,13 @@ WHERE t.workspace_id = $workspaceId
 
 ## 6. Edge Cases
 
-| Scenario | Handling |
-|---|---|
-| Same account funded multiple times at different rates | Each top-up creates a new `currency_conversion`. Transactions are assigned to the conversion with the latest `effectiveFrom ≤ tx.date`. |
-| User corrects a rate after the fact | Update `exchange_rate` on the `currency_conversions` row, then recompute `eur_amount` on all linked transactions (`conversionId = correctedId`). |
-| EUR CSV uploaded before SEK CSV | The outgoing EUR transaction exists with no match yet. When SEK CSV is uploaded later, matching runs and finds it. |
-| SEK CSV uploaded before EUR CSV | Transactions are UNRESOLVED. Banner shown. Resolved retroactively when EUR CSV is uploaded. |
-| Multiple candidate EUR transactions match the same top-up | Flag as MEDIUM confidence; pick the candidate with the smallest date delta. Show the card with an extra note: "Multiple candidates found — please verify." |
+| Scenario                                                    | Handling                                                                                                                                                                                                                 |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Same account funded multiple times at different rates       | Each top-up creates a new `currency_conversion`. Transactions are assigned to the conversion with the latest `effectiveFrom ≤ tx.date`.                                                                                  |
+| User corrects a rate after the fact                         | Update `exchange_rate` on the `currency_conversions` row, then recompute `eur_amount` on all linked transactions (`conversionId = correctedId`).                                                                         |
+| EUR CSV uploaded before SEK CSV                             | The outgoing EUR transaction exists with no match yet. When SEK CSV is uploaded later, matching runs and finds it.                                                                                                       |
+| SEK CSV uploaded before EUR CSV                             | Transactions are UNRESOLVED. Banner shown. Resolved retroactively when EUR CSV is uploaded.                                                                                                                              |
+| Multiple candidate EUR transactions match the same top-up   | Flag as MEDIUM confidence; pick the candidate with the smallest date delta. Show the card with an extra note: "Multiple candidates found — please verify."                                                               |
 | Account funded in non-EUR foreign currency (e.g. USD → SEK) | Out of scope for initial implementation. Schema supports it (`fromAmount` / `toAmount` have no currency assumption), but the UI and matching logic should guard against this case and surface it as unsupported for now. |
 
 ---

--- a/scripts/seed-categories.ts
+++ b/scripts/seed-categories.ts
@@ -1,0 +1,98 @@
+/**
+ * Seeds default categories into an existing workspace.
+ * Useful when a workspace was created before category seeding was added.
+ *
+ *   npx tsx scripts/seed-categories.ts --workspaceId=<id>
+ *
+ * Skips any category whose name already exists at the top level in that workspace.
+ */
+
+// Load .env file (Node 20.12+ built-in)
+try {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(process as any).loadEnvFile('.env');
+} catch {
+	// Env vars may already be set in the shell
+}
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+	console.error('Error: DATABASE_URL is not set. Make sure .env is present.');
+	process.exit(1);
+}
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { and, eq, isNull } from 'drizzle-orm';
+
+const args = Object.fromEntries(
+	process.argv
+		.slice(2)
+		.filter((a) => a.startsWith('--'))
+		.map((a) => {
+			const [key, ...rest] = a.slice(2).split('=');
+			return [key, rest.join('=')];
+		})
+);
+
+const workspaceId = args['workspaceId'];
+if (!workspaceId) {
+	console.error('Usage: npx tsx scripts/seed-categories.ts --workspaceId=<id>');
+	process.exit(1);
+}
+
+const client = postgres(DATABASE_URL);
+const { categories, workspaces } = await import('../src/lib/server/db/schema.js');
+const db = drizzle(client, { schema: { categories, workspaces } });
+
+// Verify workspace exists
+const ws = await db.query.workspaces.findFirst({ where: eq(workspaces.id, workspaceId) });
+if (!ws) {
+	console.error(`Workspace "${workspaceId}" not found.`);
+	await client.end();
+	process.exit(1);
+}
+
+console.log(`Seeding categories for workspace "${ws.name}" (${workspaceId})...`);
+
+const defaults = [
+	{ name: 'Restaurants', color: '#f97316', sortOrder: 0 },
+	{ name: 'Coffee', color: '#a16207', sortOrder: 1 },
+	{ name: 'Groceries', color: '#16a34a', sortOrder: 2 },
+	{ name: 'Transport', color: '#2563eb', sortOrder: 3 },
+	{ name: 'Travel', color: '#7c3aed', sortOrder: 4 },
+	{ name: 'Sports', color: '#0891b2', sortOrder: 5 },
+	{ name: 'Health', color: '#dc2626', sortOrder: 6 },
+	{ name: 'Subscriptions', color: '#9333ea', sortOrder: 7 },
+	{ name: 'Transfers', color: '#6b7280', sortOrder: 8 },
+	{ name: 'Savings', color: '#15803d', sortOrder: 9 },
+	{ name: 'Shopping', color: '#db2777', sortOrder: 10 },
+	{ name: 'Utilities', color: '#b45309', sortOrder: 11 },
+	{ name: 'Income', color: '#059669', sortOrder: 12 },
+	{ name: 'Other', color: '#78716c', sortOrder: 13 }
+];
+
+// Fetch existing top-level category names to skip duplicates
+const existing = await db
+	.select({ name: categories.name })
+	.from(categories)
+	.where(and(eq(categories.workspaceId, workspaceId), isNull(categories.parentId)));
+
+const existingNames = new Set(existing.map((r) => r.name));
+
+const toInsert = defaults.filter((d) => !existingNames.has(d.name));
+
+if (toInsert.length === 0) {
+	console.log('All default categories already exist. Nothing to do.');
+} else {
+	await db.insert(categories).values(toInsert.map((d) => ({ ...d, workspaceId })));
+	console.log(`Inserted ${toInsert.length} categories:`);
+	for (const cat of toInsert) {
+		console.log(`  + ${cat.name}`);
+	}
+	if (existingNames.size > 0) {
+		console.log(`Skipped ${existingNames.size} already existing.`);
+	}
+}
+
+await client.end();

--- a/scripts/seed-owner.ts
+++ b/scripts/seed-owner.ts
@@ -48,7 +48,7 @@ if (!email || !name || !password) {
 
 // Set up DB client
 const client = postgres(DATABASE_URL);
-const { authUser, authSession, authAccount, authVerification, workspaces } =
+const { authUser, authSession, authAccount, authVerification, workspaces, categories } =
 	await import('../src/lib/server/db/schema.js');
 const db = drizzle(client, { schema: { authUser, workspaces } });
 
@@ -104,6 +104,25 @@ if (!workspaceId) {
 		.values({ name: `${name}'s workspace`, ownerId: createdUser.id })
 		.returning({ id: workspaces.id });
 	workspaceId = ws.id;
+
+	// Seed default categories for the new workspace
+	await db.insert(categories).values([
+		{ workspaceId, name: 'Restaurants', color: '#f97316', sortOrder: 0 },
+		{ workspaceId, name: 'Coffee', color: '#a16207', sortOrder: 1 },
+		{ workspaceId, name: 'Groceries', color: '#16a34a', sortOrder: 2 },
+		{ workspaceId, name: 'Transport', color: '#2563eb', sortOrder: 3 },
+		{ workspaceId, name: 'Travel', color: '#7c3aed', sortOrder: 4 },
+		{ workspaceId, name: 'Sports', color: '#0891b2', sortOrder: 5 },
+		{ workspaceId, name: 'Health', color: '#dc2626', sortOrder: 6 },
+		{ workspaceId, name: 'Subscriptions', color: '#9333ea', sortOrder: 7 },
+		{ workspaceId, name: 'Transfers', color: '#6b7280', sortOrder: 8 },
+		{ workspaceId, name: 'Savings', color: '#15803d', sortOrder: 9 },
+		{ workspaceId, name: 'Shopping', color: '#db2777', sortOrder: 10 },
+		{ workspaceId, name: 'Utilities', color: '#b45309', sortOrder: 11 },
+		{ workspaceId, name: 'Income', color: '#059669', sortOrder: 12 },
+		{ workspaceId, name: 'Other', color: '#78716c', sortOrder: 13 }
+	]);
+	console.log('  Default categories seeded.');
 }
 
 // Set role=owner and workspaceId on the user

--- a/src/lib/components/CategorySelector.svelte
+++ b/src/lib/components/CategorySelector.svelte
@@ -49,7 +49,7 @@
 	<Popover.Trigger
 		class={cn(
 			'inline-flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 text-xs outline-none',
-			'hover:bg-surface-sunken focus-visible:ring-1 focus-visible:ring-primary-400',
+			'hover:bg-surface-sunken focus-visible:ring-1 focus-visible:ring-primary-400', 'w-full',
 			pending && 'opacity-50'
 		)}
 		disabled={pending}
@@ -71,7 +71,7 @@
 	</Popover.Trigger>
 
 	<Popover.Content
-		class="z-50 w-52 rounded-lg border border-border bg-surface p-1 shadow-md"
+		class="z-50 w-52 rounded-lg border border-border bg-surface p-1 gap-1 shadow-md max-h-72 overflow-y-auto"
 		align="start"
 		sideOffset={4}
 	>

--- a/src/lib/components/CategorySelector.svelte
+++ b/src/lib/components/CategorySelector.svelte
@@ -49,15 +49,14 @@
 	<Popover.Trigger
 		class={cn(
 			'inline-flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 text-xs outline-none',
-			'hover:bg-surface-sunken focus-visible:ring-1 focus-visible:ring-primary-400', 'w-full',
+			'hover:bg-surface-sunken focus-visible:ring-1 focus-visible:ring-primary-400',
+			'w-full',
 			pending && 'opacity-50'
 		)}
 		disabled={pending}
 	>
 		{#if effectiveCat}
-			<span
-				class="h-1.5 w-1.5 shrink-0 rounded-full"
-				style="background-color: {effectiveCat.color}"
+			<span class="h-1.5 w-1.5 shrink-0 rounded-full" style="background-color: {effectiveCat.color}"
 			></span>
 			<span class={localOverride ? 'text-text-primary' : 'text-text-secondary'}>
 				{effective}
@@ -71,7 +70,7 @@
 	</Popover.Trigger>
 
 	<Popover.Content
-		class="z-50 w-52 rounded-lg border border-border bg-surface p-1 gap-1 shadow-md max-h-72 overflow-y-auto"
+		class="z-50 max-h-72 w-52 gap-1 overflow-y-auto rounded-lg border border-border bg-surface p-1 shadow-md"
 		align="start"
 		sideOffset={4}
 	>
@@ -95,9 +94,7 @@
 					effective === parent.name ? 'font-medium text-text-primary' : 'text-text-secondary'
 				)}
 			>
-				<span
-					class="h-1.5 w-1.5 shrink-0 rounded-full"
-					style="background-color: {parent.color}"
+				<span class="h-1.5 w-1.5 shrink-0 rounded-full" style="background-color: {parent.color}"
 				></span>
 				{parent.name}
 			</button>
@@ -109,9 +106,7 @@
 						effective === child.name ? 'font-medium text-text-primary' : 'text-text-secondary'
 					)}
 				>
-					<span
-						class="h-1.5 w-1.5 shrink-0 rounded-full"
-						style="background-color: {child.color}"
+					<span class="h-1.5 w-1.5 shrink-0 rounded-full" style="background-color: {child.color}"
 					></span>
 					{child.name}
 				</button>

--- a/src/lib/components/CategorySelector.svelte
+++ b/src/lib/components/CategorySelector.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import * as Popover from '$lib/components/ui/popover';
+	import { cn } from '$lib/utils';
+	import type { CategoryRow } from '$lib/types';
+
+	interface Props {
+		txId: string;
+		category: string | null;
+		categoryOverride: string | null;
+		categories: CategoryRow[];
+	}
+	let { txId, category, categoryOverride, categories }: Props = $props();
+
+	let open = $state(false);
+	let pending = $state(false);
+	let localOverride = $state(categoryOverride);
+
+	const effective = $derived(localOverride ?? category);
+
+	const effectiveCat = $derived(categories.find((c) => c.name === effective) ?? null);
+
+	// Build grouped list: parents with their children
+	const grouped = $derived(
+		categories
+			.filter((c) => c.parentId === null)
+			.map((p) => ({ ...p, children: categories.filter((c) => c.parentId === p.id) }))
+	);
+
+	async function select(name: string | null) {
+		open = false;
+		if (name === localOverride) return;
+		pending = true;
+		try {
+			const res = await fetch(`/api/transactions/${txId}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ categoryOverride: name })
+			});
+			if (res.ok) {
+				localOverride = name;
+			}
+		} finally {
+			pending = false;
+		}
+	}
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger
+		class={cn(
+			'inline-flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 text-xs outline-none',
+			'hover:bg-surface-sunken focus-visible:ring-1 focus-visible:ring-primary-400',
+			pending && 'opacity-50'
+		)}
+		disabled={pending}
+	>
+		{#if effectiveCat}
+			<span
+				class="h-1.5 w-1.5 shrink-0 rounded-full"
+				style="background-color: {effectiveCat.color}"
+			></span>
+			<span class={localOverride ? 'text-text-primary' : 'text-text-secondary'}>
+				{effective}
+			</span>
+		{:else if effective}
+			<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-primary-400"></span>
+			<span class="text-text-secondary">{effective}</span>
+		{:else}
+			<span class="text-text-tertiary">—</span>
+		{/if}
+	</Popover.Trigger>
+
+	<Popover.Content
+		class="z-50 w-52 rounded-lg border border-border bg-surface p-1 shadow-md"
+		align="start"
+		sideOffset={4}
+	>
+		<!-- Clear option — only shown when there's something to clear -->
+		{#if effective}
+			<button
+				onclick={() => select(null)}
+				class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs text-text-tertiary outline-none hover:bg-surface-sunken"
+			>
+				No category
+			</button>
+			<div class="-mx-1 my-1 h-px bg-border"></div>
+		{/if}
+
+		<!-- Category tree -->
+		{#each grouped as parent}
+			<button
+				onclick={() => select(parent.name)}
+				class={cn(
+					'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs outline-none hover:bg-surface-sunken',
+					effective === parent.name ? 'font-medium text-text-primary' : 'text-text-secondary'
+				)}
+			>
+				<span
+					class="h-1.5 w-1.5 shrink-0 rounded-full"
+					style="background-color: {parent.color}"
+				></span>
+				{parent.name}
+			</button>
+			{#each parent.children as child}
+				<button
+					onclick={() => select(child.name)}
+					class={cn(
+						'flex w-full items-center gap-2 rounded-md py-1.5 pr-2.5 pl-6 text-left text-xs outline-none hover:bg-surface-sunken',
+						effective === child.name ? 'font-medium text-text-primary' : 'text-text-secondary'
+					)}
+				>
+					<span
+						class="h-1.5 w-1.5 shrink-0 rounded-full"
+						style="background-color: {child.color}"
+					></span>
+					{child.name}
+				</button>
+			{/each}
+		{/each}
+
+		{#if grouped.length === 0}
+			<p class="px-2.5 py-2 text-xs text-text-tertiary">No categories yet</p>
+		{/if}
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/components/settings/CategoryFormSheet.svelte
+++ b/src/lib/components/settings/CategoryFormSheet.svelte
@@ -17,8 +17,12 @@
 		category?: CategoryRow | null;
 	}
 
-	let { open = $bindable(false), mode = 'create', parentId = null, category = null }: Props =
-		$props();
+	let {
+		open = $bindable(false),
+		mode = 'create',
+		parentId = null,
+		category = null
+	}: Props = $props();
 
 	let name = $state('');
 	let color = $state('#6b7280');
@@ -34,11 +38,7 @@
 	});
 
 	const title = $derived(
-		mode === 'edit'
-			? 'Edit category'
-			: parentId
-				? 'Add subcategory'
-				: 'Add category'
+		mode === 'edit' ? 'Edit category' : parentId ? 'Add subcategory' : 'Add category'
 	);
 
 	async function handleSubmit(e: SubmitEvent) {
@@ -88,7 +88,9 @@
 		<Sheet.Header>
 			<Sheet.Title>{title}</Sheet.Title>
 			<Sheet.Description>
-				{mode === 'edit' ? 'Update the name or color.' : 'Choose a name and color for the category.'}
+				{mode === 'edit'
+					? 'Update the name or color.'
+					: 'Choose a name and color for the category.'}
 			</Sheet.Description>
 		</Sheet.Header>
 

--- a/src/lib/components/settings/CategoryFormSheet.svelte
+++ b/src/lib/components/settings/CategoryFormSheet.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import * as Sheet from '$lib/components/ui/sheet';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import ColorPicker from './ColorPicker.svelte';
+	import type { CategoryRow } from '$lib/types';
+
+	interface Props {
+		open?: boolean;
+		/** 'create' to add a new category; 'edit' to update an existing one */
+		mode?: 'create' | 'edit';
+		/** Set when creating a subcategory */
+		parentId?: string | null;
+		/** Set when editing an existing category */
+		category?: CategoryRow | null;
+	}
+
+	let { open = $bindable(false), mode = 'create', parentId = null, category = null }: Props =
+		$props();
+
+	let name = $state('');
+	let color = $state('#6b7280');
+	let submitting = $state(false);
+	let fieldError = $state<string | null>(null);
+
+	$effect(() => {
+		if (open) {
+			name = mode === 'edit' && category ? category.name : '';
+			color = mode === 'edit' && category ? category.color : '#6b7280';
+			fieldError = null;
+		}
+	});
+
+	const title = $derived(
+		mode === 'edit'
+			? 'Edit category'
+			: parentId
+				? 'Add subcategory'
+				: 'Add category'
+	);
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		fieldError = null;
+
+		const trimmedName = name.trim();
+		if (!trimmedName) {
+			fieldError = 'Name is required';
+			return;
+		}
+
+		submitting = true;
+		try {
+			const url =
+				mode === 'edit' && category
+					? `/api/settings/categories/${category.id}`
+					: '/api/settings/categories';
+
+			const body =
+				mode === 'edit'
+					? { name: trimmedName, color }
+					: { name: trimmedName, color, parentId: parentId ?? null };
+
+			const res = await fetch(url, {
+				method: mode === 'edit' ? 'PATCH' : 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+			});
+
+			if (!res.ok) {
+				const data = await res.json().catch(() => ({ message: 'Something went wrong' }));
+				fieldError = data.message ?? 'Something went wrong';
+				return;
+			}
+
+			await invalidateAll();
+			open = false;
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<Sheet.Root bind:open>
+	<Sheet.Content side="right" class="flex w-full flex-col sm:max-w-md">
+		<Sheet.Header>
+			<Sheet.Title>{title}</Sheet.Title>
+			<Sheet.Description>
+				{mode === 'edit' ? 'Update the name or color.' : 'Choose a name and color for the category.'}
+			</Sheet.Description>
+		</Sheet.Header>
+
+		<form onsubmit={handleSubmit} class="flex flex-1 flex-col gap-5 overflow-y-auto px-6 py-2">
+			<!-- Name -->
+			<div class="grid gap-1.5">
+				<Label for="cat-name">Name</Label>
+				<Input
+					id="cat-name"
+					bind:value={name}
+					placeholder="e.g. Groceries"
+					maxlength={50}
+					required
+					disabled={submitting}
+				/>
+			</div>
+
+			<!-- Color -->
+			<div class="grid gap-1.5">
+				<Label>Color</Label>
+				<div class="flex items-center gap-3">
+					<ColorPicker bind:value={color} />
+					<span class="font-mono text-sm text-text-secondary">{color}</span>
+				</div>
+			</div>
+
+			{#if fieldError}
+				<p class="text-sm text-danger-600">{fieldError}</p>
+			{/if}
+		</form>
+
+		<Sheet.Footer class="px-6 pt-2 pb-6">
+			<Sheet.Close>
+				{#snippet child({ props })}
+					<Button variant="outline" {...props} disabled={submitting}>Cancel</Button>
+				{/snippet}
+			</Sheet.Close>
+			<Button
+				onclick={(e: MouseEvent) => {
+					const form = (e.currentTarget as HTMLElement)
+						.closest('[data-slot="sheet-content"]')
+						?.querySelector('form');
+					form?.requestSubmit();
+				}}
+				disabled={submitting || !name.trim()}
+			>
+				{submitting ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Add'}
+			</Button>
+		</Sheet.Footer>
+	</Sheet.Content>
+</Sheet.Root>

--- a/src/lib/components/settings/CategoryList.svelte
+++ b/src/lib/components/settings/CategoryList.svelte
@@ -32,20 +32,26 @@
 			}
 		}
 
-		return parents.map((p): CategoryGroup => ({
-			parent: p,
-			children: childMap.get(p.id) ?? []
-		}));
+		return parents.map(
+			(p): CategoryGroup => ({
+				parent: p,
+				children: childMap.get(p.id) ?? []
+			})
+		);
 	});
 </script>
 
 <div class="space-y-1">
 	{#if groups.length === 0}
-		<div class="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border py-12">
+		<div
+			class="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border py-12"
+		>
 			<Tags size={32} class="text-text-tertiary" />
 			<div class="text-center">
 				<p class="text-sm font-medium text-text-primary">No categories yet</p>
-				<p class="mt-1 text-xs text-text-secondary">Add categories to organise your transactions.</p>
+				<p class="mt-1 text-xs text-text-secondary">
+					Add categories to organise your transactions.
+				</p>
 			</div>
 			{#if isOwner}
 				<Button size="sm" onclick={() => (addOpen = true)}>Add category</Button>

--- a/src/lib/components/settings/CategoryList.svelte
+++ b/src/lib/components/settings/CategoryList.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { Tags } from '@lucide/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import CategoryRow from './CategoryRow.svelte';
+	import CategoryFormSheet from './CategoryFormSheet.svelte';
+	import type { CategoryRow as CategoryRowType } from '$lib/types';
+
+	interface Props {
+		categories: CategoryRowType[];
+		isOwner: boolean;
+	}
+
+	let { categories, isOwner }: Props = $props();
+
+	let addOpen = $state(false);
+
+	interface CategoryGroup {
+		parent: CategoryRowType;
+		children: CategoryRowType[];
+	}
+
+	// Build tree: group subcategories under their parents
+	const groups = $derived.by(() => {
+		const parents = categories.filter((c) => c.parentId === null);
+		const childMap = new Map<string, CategoryRowType[]>();
+
+		for (const c of categories) {
+			if (c.parentId !== null) {
+				const arr = childMap.get(c.parentId) ?? [];
+				arr.push(c);
+				childMap.set(c.parentId, arr);
+			}
+		}
+
+		return parents.map((p): CategoryGroup => ({
+			parent: p,
+			children: childMap.get(p.id) ?? []
+		}));
+	});
+</script>
+
+<div class="space-y-1">
+	{#if groups.length === 0}
+		<div class="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border py-12">
+			<Tags size={32} class="text-text-tertiary" />
+			<div class="text-center">
+				<p class="text-sm font-medium text-text-primary">No categories yet</p>
+				<p class="mt-1 text-xs text-text-secondary">Add categories to organise your transactions.</p>
+			</div>
+			{#if isOwner}
+				<Button size="sm" onclick={() => (addOpen = true)}>Add category</Button>
+			{/if}
+		</div>
+	{:else}
+		<div class="rounded-xl border border-border bg-surface">
+			{#each groups as group, i (group.parent.id)}
+				{#if i > 0}
+					<div class="mx-3 h-px bg-border"></div>
+				{/if}
+				<CategoryRow
+					category={group.parent}
+					{isOwner}
+					isChild={false}
+					childCount={group.children.length}
+				/>
+				{#each group.children as child (child.id)}
+					<CategoryRow category={child} {isOwner} isChild={true} />
+				{/each}
+			{/each}
+		</div>
+
+		{#if isOwner}
+			<div class="pt-2">
+				<Button variant="outline" size="sm" onclick={() => (addOpen = true)}>Add category</Button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<CategoryFormSheet bind:open={addOpen} mode="create" />

--- a/src/lib/components/settings/CategoryRow.svelte
+++ b/src/lib/components/settings/CategoryRow.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { DropdownMenu } from 'bits-ui';
+	import { EllipsisVertical, Pencil, Trash2, Plus } from '@lucide/svelte';
+	import CategoryFormSheet from './CategoryFormSheet.svelte';
+	import type { CategoryRow } from '$lib/types';
+
+	interface Props {
+		category: CategoryRow;
+		isOwner: boolean;
+		/** Indented display for subcategories */
+		isChild?: boolean;
+		childCount?: number;
+	}
+
+	let { category, isOwner, isChild = false, childCount = 0 }: Props = $props();
+
+	let isRenaming = $state(false);
+	let renameValue = $state('');
+	let editOpen = $state(false);
+	let addSubOpen = $state(false);
+	let isDeleting = $state(false);
+
+	function startRename() {
+		isRenaming = true;
+		renameValue = category.name;
+	}
+
+	async function submitRename() {
+		const trimmed = renameValue.trim();
+		isRenaming = false;
+		if (!trimmed || trimmed === category.name) return;
+
+		await fetch(`/api/settings/categories/${category.id}`, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: trimmed })
+		});
+		await invalidateAll();
+	}
+
+	async function handleDelete() {
+		const msg = childCount > 0
+			? `"${category.name}" has ${childCount} subcategor${childCount === 1 ? 'y' : 'ies'}. Delete them first.`
+			: `Delete "${category.name}"? Transactions using this category will keep the label.`;
+
+		if (childCount > 0) {
+			alert(msg);
+			return;
+		}
+		if (!confirm(msg)) return;
+
+		isDeleting = true;
+		const res = await fetch(`/api/settings/categories/${category.id}`, { method: 'DELETE' });
+		if (!res.ok) {
+			const data = await res.json().catch(() => ({ message: 'Error deleting category' }));
+			alert(data.message ?? 'Error deleting category');
+		} else {
+			await invalidateAll();
+		}
+		isDeleting = false;
+	}
+</script>
+
+<div
+	class="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-surface-sunken {isChild
+		? 'ml-6'
+		: ''} {isDeleting ? 'opacity-50' : ''}"
+>
+	<!-- Color dot -->
+	<span
+		class="h-3 w-3 shrink-0 rounded-full"
+		style="background-color: {category.color}"
+	></span>
+
+	<!-- Name (or inline rename input) -->
+	<div class="min-w-0 flex-1">
+		{#if isRenaming}
+			<!-- svelte-ignore a11y_autofocus -->
+			<input
+				type="text"
+				bind:value={renameValue}
+				onblur={submitRename}
+				onkeydown={(e) => {
+					if (e.key === 'Enter') submitRename();
+					if (e.key === 'Escape') isRenaming = false;
+				}}
+				class="w-full rounded border border-border bg-surface-sunken px-1.5 py-0.5 text-sm font-medium text-text-primary outline-none focus:ring-2 focus:ring-primary-500/30"
+				autofocus
+			/>
+		{:else}
+			<span class="truncate text-sm font-medium text-text-primary">{category.name}</span>
+			{#if !isChild && childCount > 0}
+				<span class="ml-2 rounded-sm bg-surface-sunken px-1.5 py-0.5 text-xs text-text-tertiary">
+					{childCount}
+				</span>
+			{/if}
+		{/if}
+	</div>
+
+	<!-- Owner actions -->
+	{#if isOwner}
+		<div class="flex shrink-0 items-center gap-0.5">
+			{#if !isChild}
+				<button
+					class="rounded p-1 text-text-tertiary transition-colors hover:text-text-secondary"
+					onclick={() => (addSubOpen = true)}
+					title="Add subcategory"
+					type="button"
+				>
+					<Plus size={13} />
+				</button>
+			{/if}
+
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger>
+					{#snippet child({ props })}
+						<button
+							{...props}
+							type="button"
+							class="rounded p-1 text-text-tertiary transition-colors hover:text-text-secondary"
+						>
+							<EllipsisVertical size={14} />
+						</button>
+					{/snippet}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content
+					class="z-50 min-w-36 rounded-lg border border-border bg-surface p-1 text-sm shadow-md"
+					sideOffset={4}
+				>
+					<DropdownMenu.Item
+						class="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 text-text-primary outline-none hover:bg-surface-sunken"
+						onclick={startRename}
+					>
+						<Pencil size={13} class="text-text-tertiary" />
+						Rename
+					</DropdownMenu.Item>
+					<DropdownMenu.Item
+						class="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 text-text-primary outline-none hover:bg-surface-sunken"
+						onclick={() => (editOpen = true)}
+					>
+						<Pencil size={13} class="text-text-tertiary" />
+						Edit color
+					</DropdownMenu.Item>
+					<DropdownMenu.Separator class="-mx-1 my-1 h-px bg-border" />
+					<DropdownMenu.Item
+						class="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 text-danger-600 outline-none hover:bg-danger-50"
+						onclick={handleDelete}
+					>
+						<Trash2 size={13} />
+						Delete
+					</DropdownMenu.Item>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		</div>
+	{/if}
+</div>
+
+<!-- Edit sheet (color only — name handled by inline rename) -->
+<CategoryFormSheet bind:open={editOpen} mode="edit" {category} />
+
+<!-- Add subcategory sheet -->
+{#if !isChild}
+	<CategoryFormSheet bind:open={addSubOpen} mode="create" parentId={category.id} />
+{/if}

--- a/src/lib/components/settings/CategoryRow.svelte
+++ b/src/lib/components/settings/CategoryRow.svelte
@@ -40,9 +40,10 @@
 	}
 
 	async function handleDelete() {
-		const msg = childCount > 0
-			? `"${category.name}" has ${childCount} subcategor${childCount === 1 ? 'y' : 'ies'}. Delete them first.`
-			: `Delete "${category.name}"? Transactions using this category will keep the label.`;
+		const msg =
+			childCount > 0
+				? `"${category.name}" has ${childCount} subcategor${childCount === 1 ? 'y' : 'ies'}. Delete them first.`
+				: `Delete "${category.name}"? Transactions using this category will keep the label.`;
 
 		if (childCount > 0) {
 			alert(msg);
@@ -68,10 +69,7 @@
 		: ''} {isDeleting ? 'opacity-50' : ''}"
 >
 	<!-- Color dot -->
-	<span
-		class="h-3 w-3 shrink-0 rounded-full"
-		style="background-color: {category.color}"
-	></span>
+	<span class="h-3 w-3 shrink-0 rounded-full" style="background-color: {category.color}"></span>
 
 	<!-- Name (or inline rename input) -->
 	<div class="min-w-0 flex-1">

--- a/src/lib/components/settings/ColorPicker.svelte
+++ b/src/lib/components/settings/ColorPicker.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import * as Popover from '$lib/components/ui/popover';
+	import { Check } from '@lucide/svelte';
+
+	interface Props {
+		value?: string;
+		onchange?: (hex: string) => void;
+	}
+
+	let { value = $bindable('#6b7280'), onchange }: Props = $props();
+
+	const PALETTE = [
+		'#ef4444',
+		'#f97316',
+		'#eab308',
+		'#84cc16',
+		'#22c55e',
+		'#10b981',
+		'#14b8a6',
+		'#06b6d4',
+		'#3b82f6',
+		'#6366f1',
+		'#8b5cf6',
+		'#a855f7',
+		'#ec4899',
+		'#f43f5e',
+		'#d97706',
+		'#15803d',
+		'#1d4ed8',
+		'#7c3aed',
+		'#6b7280',
+		'#78716c'
+	];
+
+	let open = $state(false);
+
+	function select(hex: string) {
+		value = hex;
+		onchange?.(hex);
+		open = false;
+	}
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger>
+		{#snippet child({ props })}
+			<button
+				{...props}
+				type="button"
+				class="h-6 w-6 rounded-full border-2 border-white shadow-sm ring-1 ring-border transition-shadow hover:ring-2 hover:ring-primary-500/50"
+				style="background-color: {value}"
+				aria-label="Pick color"
+			></button>
+		{/snippet}
+	</Popover.Trigger>
+	<Popover.Content class="w-auto p-3" sideOffset={6}>
+		<div class="grid grid-cols-5 gap-1.5">
+			{#each PALETTE as hex (hex)}
+				<button
+					type="button"
+					class="relative h-6 w-6 rounded-full transition-transform hover:scale-110"
+					style="background-color: {hex}"
+					aria-label={hex}
+					onclick={() => select(hex)}
+				>
+					{#if value === hex}
+						<Check
+							size={12}
+							class="absolute inset-0 m-auto text-white drop-shadow-sm"
+							strokeWidth={3}
+						/>
+					{/if}
+				</button>
+			{/each}
+		</div>
+	</Popover.Content>
+</Popover.Root>

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -28,6 +28,7 @@ export interface TxRow {
 	isOpeningBalance: boolean;
 	notes: string | null;
 	category: string | null;
+	categoryOverride: string | null;
 	bankAccountId: string;
 	accountName: string | null;
 	bankProfileId: string | null;
@@ -96,6 +97,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 				isOpeningBalance: transactions.isOpeningBalance,
 				notes: transactions.notes,
 				category: transactions.category,
+				categoryOverride: transactions.categoryOverride,
 				bankAccountId: transactions.bankAccountId,
 				accountName: bankAccounts.displayName,
 				bankProfileId: bankAccounts.bankProfileId

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -259,6 +259,8 @@ export const categories = coreSchema.table('categories', {
 	workspaceId: text('workspace_id')
 		.notNull()
 		.references(() => workspaces.id),
+	// Self-referential: null = top-level category; set = subcategory (max 1 level)
+	parentId: text('parent_id'),
 	name: text('name').notNull(),
 	color: text('color').default('#6b7280').notNull(),
 	sortOrder: integer('sort_order').default(0).notNull(),
@@ -338,8 +340,14 @@ export const transactionOverridesRelations = relations(transactionOverrides, ({ 
 	user: one(authUser, { fields: [transactionOverrides.userId], references: [authUser.id] })
 }));
 
-export const categoriesRelations = relations(categories, ({ one }) => ({
-	workspace: one(workspaces, { fields: [categories.workspaceId], references: [workspaces.id] })
+export const categoriesRelations = relations(categories, ({ one, many }) => ({
+	workspace: one(workspaces, { fields: [categories.workspaceId], references: [workspaces.id] }),
+	parent: one(categories, {
+		fields: [categories.parentId],
+		references: [categories.id],
+		relationName: 'CategoryParent'
+	}),
+	children: many(categories, { relationName: 'CategoryParent' })
 }));
 
 export const csvColumnMappingsRelations = relations(csvColumnMappings, ({ one }) => ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,15 @@
 export type AccountVisibility = 'private' | 'stats_only' | 'full';
 
+export interface CategoryRow {
+	id: string;
+	workspaceId: string;
+	parentId: string | null;
+	name: string;
+	color: string;
+	sortOrder: number;
+	createdAt: Date | string;
+}
+
 export interface Account {
 	id: string;
 	displayName: string;

--- a/src/routes/(app)/settings/+page.server.ts
+++ b/src/routes/(app)/settings/+page.server.ts
@@ -1,0 +1,25 @@
+import { error } from '@sveltejs/kit';
+import { asc, eq, sql } from 'drizzle-orm';
+import type { PageServerLoad } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { categories } from '$lib/server/db/schema.js';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (!locals.user) error(401);
+	if (!locals.user.workspaceId) error(403);
+
+	const rows = await db
+		.select()
+		.from(categories)
+		.where(eq(categories.workspaceId, locals.user.workspaceId))
+		.orderBy(
+			sql`COALESCE(${categories.parentId}, ${categories.id})`,
+			asc(categories.sortOrder),
+			asc(categories.name)
+		);
+
+	return {
+		categories: rows,
+		isOwner: locals.user.role === 'owner'
+	};
+};

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import CategoryList from '$lib/components/settings/CategoryList.svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	type Tab = 'categories';
+	let activeTab = $state<Tab>('categories');
+
+	const tabs: { id: Tab; label: string }[] = [{ id: 'categories', label: 'Categories' }];
+</script>
+
+<div class="max-w-3xl px-4 py-6 md:px-8 md:py-8">
+	<!-- Page header -->
+	<div class="mb-6">
+		<h1 class="text-2xl font-semibold tracking-tight text-text-primary">Settings</h1>
+		<p class="mt-1 text-sm text-text-secondary">Manage your workspace preferences</p>
+	</div>
+
+	<!-- Tab bar -->
+	<div class="mb-6 flex gap-1 border-b border-border">
+		{#each tabs as tab (tab.id)}
+			<button
+				class="px-4 py-2 text-sm font-medium transition-colors {activeTab === tab.id
+					? 'border-b-2 border-primary-500 text-primary-600'
+					: 'text-text-secondary hover:text-text-primary'}"
+				onclick={() => (activeTab = tab.id)}
+			>
+				{tab.label}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Tab content -->
+	{#if activeTab === 'categories'}
+		<CategoryList categories={data.categories} isOwner={data.isOwner} />
+	{/if}
+</div>

--- a/src/routes/(app)/transactions/+page.server.ts
+++ b/src/routes/(app)/transactions/+page.server.ts
@@ -1,8 +1,8 @@
 import { error } from '@sveltejs/kit';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 import { db } from '$lib/server/db/index.js';
-import { bankAccounts } from '$lib/server/db/schema.js';
+import { bankAccounts, categories } from '$lib/server/db/schema.js';
 import { getFullAccessAccountIds } from '$lib/server/db/access.js';
 import { queryTransactions, type TxFilter } from '$lib/server/db/queries.js';
 
@@ -16,7 +16,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const filter = (url.searchParams.get('filter') ?? 'all') as TxFilter;
 	const page = Math.max(1, parseInt(url.searchParams.get('page') ?? '1'));
 
-	const [result, accounts] = await Promise.all([
+	const [result, accounts, cats] = await Promise.all([
 		queryTransactions({ accessibleIds, q, accountId, filter, page }),
 		accessibleIds.length > 0
 			? db
@@ -24,12 +24,24 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 					.from(bankAccounts)
 					.where(and(inArray(bankAccounts.id, accessibleIds), isNull(bankAccounts.deletedAt)))
 					.orderBy(bankAccounts.displayName)
+			: Promise.resolve([]),
+		locals.user.workspaceId
+			? db
+					.select()
+					.from(categories)
+					.where(eq(categories.workspaceId, locals.user.workspaceId))
+					.orderBy(
+						sql`COALESCE(${categories.parentId}, ${categories.id})`,
+						asc(categories.sortOrder),
+						asc(categories.name)
+					)
 			: Promise.resolve([])
 	]);
 
 	return {
 		...result,
 		accounts,
+		categories: cats,
 		filters: { q, accountId, filter }
 	};
 };

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -18,6 +18,7 @@
 	import { Button, buttonVariants } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import NoteHint from '$lib/components/NoteHint.svelte';
+	import CategorySelector from '$lib/components/CategorySelector.svelte';
 	import { cn } from '$lib/utils';
 	import type { PageData } from './$types';
 
@@ -389,13 +390,13 @@
 											<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-border-strong"></span>
 											Transfer
 										</span>
-									{:else if tx.category}
-										<span class="inline-flex items-center gap-1.5 text-xs text-text-secondary">
-											<span class="h-1.5 w-1.5 shrink-0 rounded-full bg-primary-400"></span>
-											{tx.category}
-										</span>
 									{:else}
-										<span class="text-xs text-text-tertiary">—</span>
+										<CategorySelector
+											txId={tx.id}
+											category={tx.category}
+											categoryOverride={tx.categoryOverride}
+											categories={data.categories}
+										/>
 									{/if}
 								</td>
 

--- a/src/routes/api/settings/categories/+server.ts
+++ b/src/routes/api/settings/categories/+server.ts
@@ -1,0 +1,75 @@
+import { error, json } from '@sveltejs/kit';
+import { and, asc, eq, isNull, sql } from 'drizzle-orm';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { categories } from '$lib/server/db/schema.js';
+
+const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+// ─── GET /api/settings/categories ────────────────────────────────────────────
+// Returns all categories for the user's workspace, ordered for display:
+// top-level categories first (by sortOrder, then name), subcategories grouped
+// under their parents. Returned as a flat array; clients build the tree.
+
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user) throw error(401, 'Unauthorized');
+	if (!locals.user.workspaceId) throw error(403, 'No workspace');
+
+	const rows = await db
+		.select()
+		.from(categories)
+		.where(eq(categories.workspaceId, locals.user.workspaceId))
+		.orderBy(
+			sql`COALESCE(${categories.parentId}, ${categories.id})`,
+			asc(categories.sortOrder),
+			asc(categories.name)
+		);
+
+	return json(rows);
+};
+
+// ─── POST /api/settings/categories ───────────────────────────────────────────
+// Creates a new category or subcategory. Owner only.
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) throw error(401, 'Unauthorized');
+	if (locals.user.role !== 'owner') throw error(403, 'Owner only');
+	if (!locals.user.workspaceId) throw error(403, 'No workspace');
+
+	const body = await request.json();
+	const { name, color = '#6b7280', parentId = null, sortOrder = 0 } = body;
+
+	if (!name?.trim()) throw error(400, 'name is required');
+	if (name.trim().length > 50) throw error(400, 'name must be 50 characters or fewer');
+	if (!COLOR_RE.test(color)) throw error(400, 'color must be a valid hex color (e.g. #f97316)');
+
+	const workspaceId = locals.user.workspaceId;
+
+	// Validate parentId: must exist in same workspace and be a top-level category
+	if (parentId !== null) {
+		const parent = await db.query.categories.findFirst({
+			where: and(eq(categories.id, parentId), eq(categories.workspaceId, workspaceId))
+		});
+		if (!parent) throw error(400, 'parentId not found in this workspace');
+		if (parent.parentId !== null) throw error(400, 'Cannot nest more than one level deep');
+	}
+
+	// Uniqueness check: no sibling with same name at same level
+	const sibling = await db.query.categories.findFirst({
+		where: and(
+			eq(categories.workspaceId, workspaceId),
+			eq(categories.name, name.trim()),
+			parentId === null
+				? isNull(categories.parentId)
+				: eq(categories.parentId, parentId)
+		)
+	});
+	if (sibling) throw error(409, `A category named "${name.trim()}" already exists at this level`);
+
+	const [created] = await db
+		.insert(categories)
+		.values({ workspaceId, name: name.trim(), color, parentId, sortOrder })
+		.returning();
+
+	return json(created, { status: 201 });
+};

--- a/src/routes/api/settings/categories/+server.ts
+++ b/src/routes/api/settings/categories/+server.ts
@@ -59,9 +59,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		where: and(
 			eq(categories.workspaceId, workspaceId),
 			eq(categories.name, name.trim()),
-			parentId === null
-				? isNull(categories.parentId)
-				: eq(categories.parentId, parentId)
+			parentId === null ? isNull(categories.parentId) : eq(categories.parentId, parentId)
 		)
 	});
 	if (sibling) throw error(409, `A category named "${name.trim()}" already exists at this level`);

--- a/src/routes/api/settings/categories/[id]/+server.ts
+++ b/src/routes/api/settings/categories/[id]/+server.ts
@@ -31,7 +31,12 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	const body = await request.json();
 	const { name, color, sortOrder, parentId } = body;
 
-	if (name === undefined && color === undefined && sortOrder === undefined && parentId === undefined)
+	if (
+		name === undefined &&
+		color === undefined &&
+		sortOrder === undefined &&
+		parentId === undefined
+	)
 		throw error(400, 'Nothing to update');
 
 	if (name !== undefined) {

--- a/src/routes/api/settings/categories/[id]/+server.ts
+++ b/src/routes/api/settings/categories/[id]/+server.ts
@@ -1,0 +1,148 @@
+import { error, json } from '@sveltejs/kit';
+import { and, count, eq, isNull } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { categories } from '$lib/server/db/schema.js';
+
+const COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+async function getOwnedCategory(categoryId: string, workspaceId: string) {
+	const category = await db.query.categories.findFirst({
+		where: and(eq(categories.id, categoryId), eq(categories.workspaceId, workspaceId))
+	});
+	if (!category) throw error(404, 'Category not found');
+	return category;
+}
+
+// ─── PATCH /api/settings/categories/[id] ─────────────────────────────────────
+// Update name, color, sortOrder, or parentId. Owner only.
+// When name changes: propagates to transactions.category, transactions.category_override,
+// and transaction_overrides.category within the workspace (atomic DB transaction).
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+	if (!locals.user) throw error(401, 'Unauthorized');
+	if (locals.user.role !== 'owner') throw error(403, 'Owner only');
+	if (!locals.user.workspaceId) throw error(403, 'No workspace');
+
+	const workspaceId = locals.user.workspaceId;
+	const existing = await getOwnedCategory(params.id, workspaceId);
+
+	const body = await request.json();
+	const { name, color, sortOrder, parentId } = body;
+
+	if (name === undefined && color === undefined && sortOrder === undefined && parentId === undefined)
+		throw error(400, 'Nothing to update');
+
+	if (name !== undefined) {
+		if (!name?.trim()) throw error(400, 'name cannot be empty');
+		if (name.trim().length > 50) throw error(400, 'name must be 50 characters or fewer');
+	}
+	if (color !== undefined && !COLOR_RE.test(color))
+		throw error(400, 'color must be a valid hex color (e.g. #f97316)');
+
+	if (parentId !== undefined && parentId !== null) {
+		const parent = await db.query.categories.findFirst({
+			where: and(eq(categories.id, parentId), eq(categories.workspaceId, workspaceId))
+		});
+		if (!parent) throw error(400, 'parentId not found in this workspace');
+		if (parent.parentId !== null) throw error(400, 'Cannot nest more than one level deep');
+	}
+
+	const newName = name !== undefined ? name.trim() : undefined;
+	const oldName = existing.name;
+	const nameChanged = newName !== undefined && newName !== oldName;
+
+	// Uniqueness check on rename
+	if (nameChanged) {
+		const resolvedParentId = parentId !== undefined ? parentId : existing.parentId;
+		const sibling = await db.query.categories.findFirst({
+			where: and(
+				eq(categories.workspaceId, workspaceId),
+				eq(categories.name, newName!),
+				resolvedParentId === null
+					? isNull(categories.parentId)
+					: eq(categories.parentId, resolvedParentId)
+			)
+		});
+		if (sibling && sibling.id !== params.id)
+			throw error(409, `A category named "${newName}" already exists at this level`);
+	}
+
+	const patch: Record<string, unknown> = {};
+	if (newName !== undefined) patch.name = newName;
+	if (color !== undefined) patch.color = color;
+	if (sortOrder !== undefined) patch.sortOrder = sortOrder;
+	if (parentId !== undefined) patch.parentId = parentId;
+
+	// Wrap in a transaction when renaming so propagation is atomic
+	const updated = await db.transaction(async (tx) => {
+		const [row] = await tx
+			.update(categories)
+			.set(patch)
+			.where(eq(categories.id, params.id))
+			.returning();
+
+		if (nameChanged) {
+			// Propagate to transactions.category
+			await tx.execute(sql`
+				UPDATE "core"."transactions" t
+				SET "category" = ${newName}
+				FROM "core"."bank_accounts" ba
+				WHERE t."category" = ${oldName}
+				  AND t."bank_account_id" = ba."id"
+				  AND ba."workspace_id" = ${workspaceId}
+			`);
+
+			// Propagate to transactions.category_override
+			await tx.execute(sql`
+				UPDATE "core"."transactions" t
+				SET "category_override" = ${newName}
+				FROM "core"."bank_accounts" ba
+				WHERE t."category_override" = ${oldName}
+				  AND t."bank_account_id" = ba."id"
+				  AND ba."workspace_id" = ${workspaceId}
+			`);
+
+			// Propagate to transaction_overrides.category
+			await tx.execute(sql`
+				UPDATE "core"."transaction_overrides" tov
+				SET "category" = ${newName}
+				FROM "core"."transactions" t
+				JOIN "core"."bank_accounts" ba ON t."bank_account_id" = ba."id"
+				WHERE tov."transaction_id" = t."id"
+				  AND tov."category" = ${oldName}
+				  AND ba."workspace_id" = ${workspaceId}
+			`);
+		}
+
+		return row;
+	});
+
+	return json(updated);
+};
+
+// ─── DELETE /api/settings/categories/[id] ────────────────────────────────────
+// Deletes a category. Owner only. Blocked if the category has subcategories.
+// Transactions that reference this category by name retain the old text (intended).
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user) throw error(401, 'Unauthorized');
+	if (locals.user.role !== 'owner') throw error(403, 'Owner only');
+	if (!locals.user.workspaceId) throw error(403, 'No workspace');
+
+	await getOwnedCategory(params.id, locals.user.workspaceId);
+
+	// Block deletion if subcategories exist
+	const [{ childCount }] = await db
+		.select({ childCount: count() })
+		.from(categories)
+		.where(eq(categories.parentId, params.id));
+
+	if (childCount > 0)
+		throw error(409, 'Delete or reassign subcategories before deleting this category');
+
+	await db.delete(categories).where(eq(categories.id, params.id));
+
+	return new Response(null, { status: 204 });
+};

--- a/src/routes/api/transactions/[id]/+server.ts
+++ b/src/routes/api/transactions/[id]/+server.ts
@@ -1,0 +1,43 @@
+import { error, json } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { transactions } from '$lib/server/db/schema.js';
+import { getFullAccessAccountIds } from '$lib/server/db/access.js';
+
+// ─── PATCH /api/transactions/[id] ────────────────────────────────────────────
+// Updates user-editable fields on a transaction.
+// Currently supports: categoryOverride (string | null)
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+	if (!locals.user) throw error(401, 'Unauthorized');
+
+	const body = await request.json();
+	const { categoryOverride } = body;
+
+	if (categoryOverride !== null && typeof categoryOverride !== 'string') {
+		throw error(400, 'categoryOverride must be a string or null');
+	}
+
+	const accessibleIds = await getFullAccessAccountIds(locals.user.id);
+	if (accessibleIds.length === 0) throw error(403, 'Forbidden');
+
+	const tx = await db.query.transactions.findFirst({
+		where: eq(transactions.id, params.id),
+		columns: { id: true, bankAccountId: true }
+	});
+
+	if (!tx) throw error(404, 'Transaction not found');
+	if (!accessibleIds.includes(tx.bankAccountId)) throw error(403, 'Forbidden');
+
+	await db
+		.update(transactions)
+		.set({
+			categoryOverride: categoryOverride ?? null,
+			categoryOverrideById: categoryOverride !== null ? locals.user.id : null,
+			updatedAt: new Date()
+		})
+		.where(eq(transactions.id, params.id));
+
+	return json({ ok: true });
+};


### PR DESCRIPTION
## Summary

- Adds `categories` table (workspace-scoped, two-level hierarchy with parent/child) and Drizzle migration
- REST API for category CRUD (`GET/POST /api/settings/categories`, `GET/PATCH/DELETE /api/settings/categories/[id]`)
- Settings → Categories tab with full management UI (create, rename inline, change colour, delete, add subcategory)
- `PATCH /api/transactions/[id]` endpoint to set `categoryOverride` on a transaction
- `CategorySelector` component: click the category cell in the transactions table to open a popover and pick from the workspace category list, with optimistic UI update
- Default categories seeded on workspace creation; `scripts/seed-categories.ts` available for existing workspaces

Closes #19