### PR TITLE
feat: rolling balance area chart on dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@tailwindcss/typography": "^0.5.19",
 				"@tailwindcss/vite": "^4.1.18",
+				"@types/d3-scale": "^4.0.9",
+				"@types/d3-shape": "^3.1.8",
 				"@types/node": "^22",
 				"better-auth": "~1.4.21",
 				"bits-ui": "^2.16.4",
@@ -3155,6 +3157,40 @@
 				"@types/d3-array": "*",
 				"@types/geojson": "*"
 			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/esrecurse": {
 			"version": "4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"@tailwindcss/vite": "^4.1.18",
 				"@types/d3-scale": "^4.0.9",
 				"@types/d3-shape": "^3.1.8",
+				"@types/d3-time": "^3.0.4",
 				"@types/node": "^22",
 				"better-auth": "~1.4.21",
 				"bits-ui": "^2.16.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-svelte": "^3.15.2",
 				"globals": "^17.4.0",
+				"layerchart": "^2.0.0-next.48",
 				"postgres": "^3.4.8",
 				"prettier": "^3.8.1",
 				"prettier-plugin-svelte": "^3.4.1",
@@ -967,6 +968,23 @@
 				"picocolors": "^1.0.0",
 				"sisteransi": "^1.0.5"
 			}
+		},
+		"node_modules/@dagrejs/dagre": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-2.0.4.tgz",
+			"integrity": "sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@dagrejs/graphlib": "3.0.4"
+			}
+		},
+		"node_modules/@dagrejs/graphlib": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-3.0.4.tgz",
+			"integrity": "sha512-HxZ7fCvAwTLCWCO0WjDkzAFQze8LdC6iOpKbetDKHIuDfIgMlIzYzqZ4nxwLlclQX+3ZVeZ1K2OuaOE2WWcyOg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@drizzle-team/brocli": {
 			"version": "0.10.2",
@@ -2175,6 +2193,53 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@layerstack/svelte-actions": {
+			"version": "1.0.1-next.18",
+			"resolved": "https://registry.npmjs.org/@layerstack/svelte-actions/-/svelte-actions-1.0.1-next.18.tgz",
+			"integrity": "sha512-gxPzCnJ1c9LTfWtRqLUzefCx+k59ZpxDUQ2XB+LokveZQPe7IDSOwHaBOEMlaGoGrtwc3Ft8dSZq+2WT2o9u/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.7.0",
+				"@layerstack/utils": "2.0.0-next.18",
+				"d3-scale": "^4.0.2"
+			}
+		},
+		"node_modules/@layerstack/svelte-state": {
+			"version": "0.1.0-next.23",
+			"resolved": "https://registry.npmjs.org/@layerstack/svelte-state/-/svelte-state-0.1.0-next.23.tgz",
+			"integrity": "sha512-7O4umv+gXwFfs3/vjzFWYHNXGwYnnjBapWJ5Y+9u99F4eVk6rh4ocNwqkqQNkpMZ5tUJBlRTWjPE1So6+hEzIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@layerstack/utils": "2.0.0-next.18"
+			}
+		},
+		"node_modules/@layerstack/tailwind": {
+			"version": "2.0.0-next.21",
+			"resolved": "https://registry.npmjs.org/@layerstack/tailwind/-/tailwind-2.0.0-next.21.tgz",
+			"integrity": "sha512-Qgp2EpmEHmjtura8MQzWicR6ztBRSsRvddakFtx9ShrLMz6jWzd6bCMVVRu44Q3ZOrtXmSu4QxjCZWu1ytvuPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@layerstack/utils": "^2.0.0-next.18",
+				"clsx": "^2.1.1",
+				"d3-array": "^3.2.4",
+				"tailwind-merge": "^3.2.0"
+			}
+		},
+		"node_modules/@layerstack/utils": {
+			"version": "2.0.0-next.18",
+			"resolved": "https://registry.npmjs.org/@layerstack/utils/-/utils-2.0.0-next.18.tgz",
+			"integrity": "sha512-EYILHpfBRYMMEahajInu9C2AXQom5IcAEdtCeucD3QIl/fdDgRbtzn6/8QW9ewumfyNZetdUvitOksmI1+gZYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"d3-array": "^3.2.4",
+				"d3-time": "^3.1.0",
+				"d3-time-format": "^4.1.0"
+			}
+		},
 		"node_modules/@lucide/svelte": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.7.0.tgz",
@@ -3073,6 +3138,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
 		"node_modules/@types/esrecurse": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -3084,6 +3167,13 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4082,6 +4172,374 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"delaunator": "5"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dispatch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+			"integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-geo-voronoi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/d3-geo-voronoi/-/d3-geo-voronoi-2.1.0.tgz",
+			"integrity": "sha512-kqE4yYuOjPbKdBXG0xztCacPwkVSK2REF1opSNrnqqtXJmNcM++UbwQ8SxvwP6IQTj9RvIjjK4qeiVsEfj0Z2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "3",
+				"d3-delaunay": "6",
+				"d3-geo": "3",
+				"d3-tricontour": "1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate-path": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/d3-interpolate-path/-/d3-interpolate-path-2.3.0.tgz",
+			"integrity": "sha512-tZYtGXxBmbgHsIc9Wms6LS5u4w6KbP8C09a4/ZYc4KLMYYqub57rRBUgpUr2CIarIrJEpdAWWxWQvofgaMpbKQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-quadtree": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+			"integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3",
+				"d3-interpolate": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-tile": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d3-tile/-/d3-tile-1.0.0.tgz",
+			"integrity": "sha512-79fnTKpPMPDS5xQ0xuS9ir0165NEwwkFpe/DSOmc2Gl9ldYzKKRDWogmTTE8wAJ8NA7PMapNfEcyKhI9Lxdu5Q==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-tricontour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/d3-tricontour/-/d3-tricontour-1.1.0.tgz",
+			"integrity": "sha512-G7gHKj89n2owmkGb6WX6ixcnQ0Kf/0wpa9VIh9DGdbHu8wdrlaHU4ir3/bFNERl8N8nn4G7e7qbtBG8N9caihQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"d3-delaunay": "6",
+				"d3-scale": "4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/date-fns": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -4202,6 +4660,16 @@
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/delaunator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
+			}
 		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
@@ -4986,6 +5454,19 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5047,6 +5528,16 @@
 			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/is-docker": {
 			"version": "3.0.0",
@@ -5248,6 +5739,76 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/layerchart": {
+			"version": "2.0.0-next.48",
+			"resolved": "https://registry.npmjs.org/layerchart/-/layerchart-2.0.0-next.48.tgz",
+			"integrity": "sha512-XoEYBztamA8lMxtF/Jz3aDX0HMk8dI+o4fK9fSl8ecT2Tdx3DQUjtKGtlQAOFdwC/AWifeLmKq5cMTQt9COZPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@dagrejs/dagre": "^2.0.4",
+				"@layerstack/svelte-actions": "1.0.1-next.18",
+				"@layerstack/svelte-state": "0.1.0-next.23",
+				"@layerstack/tailwind": "2.0.0-next.21",
+				"@layerstack/utils": "2.0.0-next.18",
+				"@types/d3-contour": "^3.0.6",
+				"d3-array": "^3.2.4",
+				"d3-chord": "^3.0.1",
+				"d3-color": "^3.1.0",
+				"d3-contour": "^4.0.2",
+				"d3-delaunay": "^6.0.4",
+				"d3-dsv": "^3.0.1",
+				"d3-force": "^3.0.0",
+				"d3-geo": "^3.1.1",
+				"d3-geo-voronoi": "^2.1.0",
+				"d3-hierarchy": "^3.1.2",
+				"d3-interpolate": "^3.0.1",
+				"d3-interpolate-path": "^2.3.0",
+				"d3-path": "^3.1.0",
+				"d3-quadtree": "^3.0.1",
+				"d3-random": "^3.0.1",
+				"d3-sankey": "^0.12.3",
+				"d3-scale": "^4.0.2",
+				"d3-scale-chromatic": "^3.1.0",
+				"d3-shape": "^3.2.0",
+				"d3-tile": "^1.0.0",
+				"d3-time": "^3.1.0",
+				"memoize": "^10.2.0",
+				"runed": "^0.37.1"
+			},
+			"peerDependencies": {
+				"svelte": "^5.0.0"
+			}
+		},
+		"node_modules/layerchart/node_modules/runed": {
+			"version": "0.37.1",
+			"resolved": "https://registry.npmjs.org/runed/-/runed-0.37.1.tgz",
+			"integrity": "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/huntabyte",
+				"https://github.com/sponsors/tglide"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.3",
+				"esm-env": "^1.0.0",
+				"lz-string": "^1.5.0"
+			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.21.0",
+				"svelte": "^5.7.0",
+				"zod": "^4.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/levn": {
@@ -5593,6 +6154,35 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/memoize": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
+			"integrity": "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/memoize?sponsor=1"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -6600,6 +7190,13 @@
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
 		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"dev": true,
+			"license": "Unlicense"
+		},
 		"node_modules/rollup": {
 			"version": "4.60.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
@@ -6690,6 +7287,13 @@
 				}
 			}
 		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -6722,6 +7326,13 @@
 					"url": "https://feross.org/support"
 				}
 			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.1.18",
+		"@types/d3-scale": "^4.0.9",
+		"@types/d3-shape": "^3.1.8",
 		"@types/node": "^22",
 		"better-auth": "~1.4.21",
 		"bits-ui": "^2.16.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.15.2",
 		"globals": "^17.4.0",
+		"layerchart": "^2.0.0-next.48",
 		"postgres": "^3.4.8",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@tailwindcss/vite": "^4.1.18",
 		"@types/d3-scale": "^4.0.9",
 		"@types/d3-shape": "^3.1.8",
+		"@types/d3-time": "^3.0.4",
 		"@types/node": "^22",
 		"better-auth": "~1.4.21",
 		"bits-ui": "^2.16.4",

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -1,0 +1,48 @@
+import { addWeeks, addMonths, addQuarters } from 'date-fns';
+import type { Granularity } from '$lib/server/db/queries.js';
+
+export interface ProjectedPoint {
+	bucket: string;
+	cumulativeBalance: number;
+	isProjected: true;
+}
+
+const adders: Record<Granularity, (date: Date, amount: number) => Date> = {
+	week: addWeeks,
+	month: addMonths,
+	quarter: addQuarters
+};
+
+/**
+ * Build a linear projection from the last actual data point to year-end.
+ * Returns an empty array if there are fewer than 2 actual points.
+ */
+export function buildProjection(
+	actual: Array<{ bucket: string; cumulativeBalance: number }>,
+	granularity: Granularity,
+	endDate: Date = new Date(new Date().getFullYear(), 11, 31)
+): ProjectedPoint[] {
+	if (actual.length < 2) return [];
+
+	const first = actual[0];
+	const last = actual[actual.length - 1];
+	const avgChangePerBucket =
+		(last.cumulativeBalance - first.cumulativeBalance) / (actual.length - 1);
+
+	const add = adders[granularity];
+	const points: ProjectedPoint[] = [];
+	let step = 1;
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const bucketDate = add(new Date(last.bucket), step);
+		if (bucketDate > endDate) break;
+		points.push({
+			bucket: bucketDate.toISOString().slice(0, 10),
+			cumulativeBalance: last.cumulativeBalance + avgChangePerBucket * step,
+			isProjected: true
+		});
+		step++;
+	}
+
+	return points;
+}

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -44,5 +44,22 @@ export function buildProjection(
 		step++;
 	}
 
+	// Always anchor the projection to endDate so the chart domain ends there for all
+	// granularities. Without this, quarterly's last bucket (Oct 1) causes scaleUtc.nice(4)
+	// to extend the domain to Jan 1 next year, leaving a blank strip on the right.
+	const lastBucketDate = points.length > 0 ? new Date(points[points.length - 1].bucket) : new Date(last.bucket);
+	if (lastBucketDate < endDate) {
+		const lastBalance = points.length > 0 ? points[points.length - 1].cumulativeBalance : last.cumulativeBalance;
+		// Use the actual next-step duration from the last bucket to get the correct fraction
+		const nextBucketDate = add(lastBucketDate, 1);
+		const bucketDurationMs = nextBucketDate.getTime() - lastBucketDate.getTime();
+		const fraction = (endDate.getTime() - lastBucketDate.getTime()) / bucketDurationMs;
+		points.push({
+			bucket: endDate.toISOString().slice(0, 10),
+			cumulativeBalance: lastBalance + avgChangePerBucket * fraction,
+			isProjected: true
+		});
+	}
+
 	return points;
 }

--- a/src/lib/components/Amount.svelte
+++ b/src/lib/components/Amount.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
+	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 	interface Props {
 		value: number;
@@ -12,7 +13,7 @@
 
 	let {
 		value,
-		currency = 'EUR',
+		currency = PRIMARY_CURRENCY,
 		size = 'md',
 		showSign = true,
 		colorize = true,

--- a/src/lib/components/BalanceChart.svelte
+++ b/src/lib/components/BalanceChart.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { format, getQuarter, getYear } from 'date-fns';
-	import { AreaChart, Area, Spline, LinearGradient } from 'layerchart';
+	import { AreaChart, Area, LinearGradient } from 'layerchart';
 	import { scaleUtc } from 'd3-scale';
 	import { curveNatural } from 'd3-shape';
 	import * as Chart from '$lib/components/ui/chart/index.js';
@@ -27,21 +27,30 @@
 	// Merged dataset drives the chart domain (x + y extents)
 	const allData = $derived([...actualData, ...projectedData]);
 
-	// Prepend the last actual point so the dashed line connects visually
-	const splineData = $derived(
+	// Prepend the last actual point so the projected area connects seamlessly
+	const projectedAreaData = $derived(
 		actualData.length > 0 && projectedData.length > 0
 			? [actualData[actualData.length - 1], ...projectedData]
 			: []
 	);
 
+	// X axis tick strategy per granularity:
+	// - quarter: ticks:4 forces d3 to snap to quarterly boundaries (Jan/Apr/Jul/Oct)
+	//   avoiding duplicate "Q1 2026 Q1 2026 Q1 2026" that appear with monthly d3 ticks
+	// - week/month: tickSpacing only — layerchart auto-reduces ticks to fit the
+	//   container width, giving responsive behaviour without JS resize listeners
+	const xTicks = $derived(granularity === 'quarter' ? 4 : undefined);
+	const xTickSpacing = $derived(granularity === 'week' ? 70 : 80);
+
 	// Chart.Container config maps the default series key to a label + color
 	const chartConfig = {
-		default: { label: 'Balance', color: 'var(--color-chart-1)' }
+		default: { label: 'Balance', color: 'var(--color-primary-500)' }
 	} satisfies Chart.ChartConfig;
 
 	function formatTick(date: Date): string {
 		if (granularity === 'week') return format(date, 'MMM d');
-		if (granularity === 'quarter') return `Q${getQuarter(date)} ${getYear(date)}`;
+		// Shorten quarter label so 4 labels always fit: "Q1 '26"
+		if (granularity === 'quarter') return `Q${getQuarter(date)} '${String(getYear(date)).slice(2)}`;
 		return format(date, 'MMM yy');
 	}
 
@@ -51,14 +60,28 @@
 		return format(date, 'MMMM yyyy');
 	}
 
+	// Y axis: avoid the Spanish compact "mil €" ambiguity — use K suffix instead
+	function formatYAxis(v: number): string {
+		const abs = Math.abs(v);
+		const sign = v < 0 ? '-' : '';
+		if (abs >= 1000) {
+			const k = abs / 1000;
+			return `${sign}${k.toLocaleString('es-ES', { maximumFractionDigits: 1 })}K €`;
+		}
+		return `${sign}${abs.toLocaleString('es-ES', { maximumFractionDigits: 0 })} €`;
+	}
+
 	function formatBalance(v: number): string {
 		return new Intl.NumberFormat('es-ES', {
 			style: 'currency',
 			currency: PRIMARY_CURRENCY,
-			notation: 'compact',
-			maximumFractionDigits: 1
+			minimumFractionDigits: 0,
+			maximumFractionDigits: 0
 		}).format(v);
 	}
+
+	const lineStyle = 'stroke: var(--color-primary-500); stroke-width: 2px;';
+	const dashedLineStyle = `${lineStyle} stroke-dasharray: 4 4;`;
 </script>
 
 {#snippet balanceFormatter({
@@ -72,14 +95,14 @@
 })}
 	<div class="flex w-full items-center justify-between gap-6">
 		<div class="flex items-center gap-1.5">
-			<div class="size-2.5 rounded-[2px] bg-[--color-chart-1]"></div>
+			<div class="size-2.5 rounded-[2px] bg-[--color-primary-500]"></div>
 			<span class="text-muted-foreground">Balance</span>
 		</div>
 		<span class="font-mono font-medium tabular-nums">{formatBalance(value as number)}</span>
 	</div>
 {/snippet}
 
-<Chart.Container config={chartConfig} class={cn('h-56 md:h-64', cls)}>
+<Chart.Container config={chartConfig} class={cn('aspect-auto h-56 md:h-64', cls)}>
 	{#if browser}
 		<AreaChart
 			data={allData}
@@ -88,38 +111,44 @@
 			y="cumulativeBalance"
 			yPadding={[0, 20]}
 			props={{
-				xAxis: { format: (v: Date) => formatTick(v) },
-				yAxis: { format: (v: number) => formatBalance(v) }
+				xAxis: {
+					format: (v: Date) => formatTick(v),
+					ticks: xTicks,
+					tickSpacing: xTickSpacing
+				},
+				yAxis: { format: (v: number) => formatYAxis(v) }
 			}}
 		>
 			{#snippet marks()}
-				<!-- Actual balance: filled area with vertical gradient -->
 				<LinearGradient
 					stops={[
-						'var(--color-chart-1)',
-						'color-mix(in lch, var(--color-chart-1) 5%, transparent)'
+						'var(--color-primary-500)',
+						'color-mix(in lch, var(--color-primary-500) 5%, transparent)'
 					]}
 					vertical
 				>
 					{#snippet children({ gradient })}
+						<!-- Actual balance: solid pink line + gradient fill -->
 						<Area
 							data={actualData}
 							curve={curveNatural}
 							fill={gradient}
 							fillOpacity={0.4}
-							line={{ class: 'stroke-2 stroke-[--color-chart-1]' }}
+							line={{ style: lineStyle }}
 						/>
+
+						<!-- Projected trend: same gradient fill, dashed pink line -->
+						{#if projectedAreaData.length > 1}
+							<Area
+								data={projectedAreaData}
+								curve={curveNatural}
+								fill={gradient}
+								fillOpacity={0.4}
+								line={{ style: dashedLineStyle }}
+							/>
+						{/if}
 					{/snippet}
 				</LinearGradient>
-
-				<!-- Projected trend: dashed line from last actual point to year-end -->
-				{#if splineData.length > 1}
-					<Spline
-						data={splineData}
-						curve={curveNatural}
-						class="stroke-[--color-chart-2] stroke-2 [stroke-dasharray:4_4]"
-					/>
-				{/if}
 			{/snippet}
 
 			{#snippet tooltip()}

--- a/src/lib/components/BalanceChart.svelte
+++ b/src/lib/components/BalanceChart.svelte
@@ -61,7 +61,15 @@
 	}
 </script>
 
-{#snippet balanceFormatter({ value }: { value: unknown; name: string; item: TooltipPayload; index: number; payload: TooltipPayload[] })}
+{#snippet balanceFormatter({
+	value
+}: {
+	value: unknown;
+	name: string;
+	item: TooltipPayload;
+	index: number;
+	payload: TooltipPayload[];
+})}
 	<div class="flex w-full items-center justify-between gap-6">
 		<div class="flex items-center gap-1.5">
 			<div class="size-2.5 rounded-[2px] bg-[--color-chart-1]"></div>
@@ -109,7 +117,7 @@
 					<Spline
 						data={splineData}
 						curve={curveNatural}
-						class="stroke-2 stroke-[--color-chart-2] [stroke-dasharray:4_4]"
+						class="stroke-[--color-chart-2] stroke-2 [stroke-dasharray:4_4]"
 					/>
 				{/if}
 			{/snippet}

--- a/src/lib/components/BalanceChart.svelte
+++ b/src/lib/components/BalanceChart.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { format, getQuarter, getYear } from 'date-fns';
+	import { AreaChart, Area, Spline, LinearGradient } from 'layerchart';
+	import { scaleUtc } from 'd3-scale';
+	import { curveNatural } from 'd3-shape';
+	import * as Chart from '$lib/components/ui/chart/index.js';
+	import type { TooltipPayload } from '$lib/components/ui/chart/chart-utils.js';
+	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
+	import { cn } from '$lib/utils.js';
+	import type { BalancePoint, Granularity } from '$lib/server/db/queries.js';
+	import type { ProjectedPoint } from '$lib/chart-utils.js';
+
+	interface Props {
+		points: BalancePoint[];
+		projectedPoints: ProjectedPoint[];
+		granularity: Granularity;
+		class?: string;
+	}
+
+	let { points, projectedPoints, granularity, class: cls = '' }: Props = $props();
+
+	// Add Date objects for the x-axis (scaleUtc needs real Dates, not strings)
+	const actualData = $derived(points.map((p) => ({ ...p, date: new Date(p.bucket) })));
+	const projectedData = $derived(projectedPoints.map((p) => ({ ...p, date: new Date(p.bucket) })));
+
+	// Merged dataset drives the chart domain (x + y extents)
+	const allData = $derived([...actualData, ...projectedData]);
+
+	// Prepend the last actual point so the dashed line connects visually
+	const splineData = $derived(
+		actualData.length > 0 && projectedData.length > 0
+			? [actualData[actualData.length - 1], ...projectedData]
+			: []
+	);
+
+	// Chart.Container config maps the default series key to a label + color
+	const chartConfig = {
+		default: { label: 'Balance', color: 'var(--color-chart-1)' }
+	} satisfies Chart.ChartConfig;
+
+	function formatTick(date: Date): string {
+		if (granularity === 'week') return format(date, 'MMM d');
+		if (granularity === 'quarter') return `Q${getQuarter(date)} ${getYear(date)}`;
+		return format(date, 'MMM yy');
+	}
+
+	function formatTooltipLabel(date: Date): string {
+		if (granularity === 'week') return format(date, 'd MMM yyyy');
+		if (granularity === 'quarter') return `Q${getQuarter(date)} ${getYear(date)}`;
+		return format(date, 'MMMM yyyy');
+	}
+
+	function formatBalance(v: number): string {
+		return new Intl.NumberFormat('es-ES', {
+			style: 'currency',
+			currency: PRIMARY_CURRENCY,
+			notation: 'compact',
+			maximumFractionDigits: 1
+		}).format(v);
+	}
+</script>
+
+{#snippet balanceFormatter({ value }: { value: unknown; name: string; item: TooltipPayload; index: number; payload: TooltipPayload[] })}
+	<div class="flex w-full items-center justify-between gap-6">
+		<div class="flex items-center gap-1.5">
+			<div class="size-2.5 rounded-[2px] bg-[--color-chart-1]"></div>
+			<span class="text-muted-foreground">Balance</span>
+		</div>
+		<span class="font-mono font-medium tabular-nums">{formatBalance(value as number)}</span>
+	</div>
+{/snippet}
+
+<Chart.Container config={chartConfig} class={cn('h-56 md:h-64', cls)}>
+	{#if browser}
+		<AreaChart
+			data={allData}
+			x="date"
+			xScale={scaleUtc()}
+			y="cumulativeBalance"
+			yPadding={[0, 20]}
+			props={{
+				xAxis: { format: (v: Date) => formatTick(v) },
+				yAxis: { format: (v: number) => formatBalance(v) }
+			}}
+		>
+			{#snippet marks()}
+				<!-- Actual balance: filled area with vertical gradient -->
+				<LinearGradient
+					stops={[
+						'var(--color-chart-1)',
+						'color-mix(in lch, var(--color-chart-1) 5%, transparent)'
+					]}
+					vertical
+				>
+					{#snippet children({ gradient })}
+						<Area
+							data={actualData}
+							curve={curveNatural}
+							fill={gradient}
+							fillOpacity={0.4}
+							line={{ class: 'stroke-2 stroke-[--color-chart-1]' }}
+						/>
+					{/snippet}
+				</LinearGradient>
+
+				<!-- Projected trend: dashed line from last actual point to year-end -->
+				{#if splineData.length > 1}
+					<Spline
+						data={splineData}
+						curve={curveNatural}
+						class="stroke-2 stroke-[--color-chart-2] [stroke-dasharray:4_4]"
+					/>
+				{/if}
+			{/snippet}
+
+			{#snippet tooltip()}
+				<Chart.Tooltip
+					labelFormatter={(v: Date) => formatTooltipLabel(v)}
+					formatter={balanceFormatter}
+				/>
+			{/snippet}
+		</AreaChart>
+	{:else}
+		<!-- SSR placeholder — same dimensions to avoid layout shift -->
+		<div class="h-full w-full animate-pulse rounded-lg bg-surface-sunken"></div>
+	{/if}
+</Chart.Container>

--- a/src/lib/components/GranularitySelector.svelte
+++ b/src/lib/components/GranularitySelector.svelte
@@ -16,7 +16,7 @@
 	];
 </script>
 
-<div class="flex items-center rounded-lg border border-border bg-surface-sunken p-0.5 gap-0.5">
+<div class="flex items-center gap-0.5 rounded-lg border border-border bg-surface-sunken p-0.5">
 	{#each options as opt (opt.value)}
 		<button
 			type="button"

--- a/src/lib/components/GranularitySelector.svelte
+++ b/src/lib/components/GranularitySelector.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { Granularity } from '$lib/server/db/queries.js';
+
+	interface Props {
+		value: Granularity;
+		onchange: (g: Granularity) => void;
+	}
+
+	let { value, onchange }: Props = $props();
+
+	const options: { label: string; value: Granularity }[] = [
+		{ label: 'W', value: 'week' },
+		{ label: 'M', value: 'month' },
+		{ label: 'Q', value: 'quarter' }
+	];
+</script>
+
+<div class="flex items-center rounded-lg border border-border bg-surface-sunken p-0.5 gap-0.5">
+	{#each options as opt (opt.value)}
+		<button
+			type="button"
+			onclick={() => onchange(opt.value)}
+			class={cn(
+				'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+				value === opt.value
+					? 'bg-surface text-text-primary shadow-sm'
+					: 'text-text-tertiary hover:text-text-secondary'
+			)}
+		>
+			{opt.label}
+		</button>
+	{/each}
+</div>

--- a/src/lib/components/accounts/AddAccountSheet.svelte
+++ b/src/lib/components/accounts/AddAccountSheet.svelte
@@ -4,7 +4,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import { CURRENCIES } from '$lib/currencies.js';
+	import { CURRENCIES, PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 	interface Profile {
 		id: string;
@@ -22,7 +22,7 @@
 	let displayName = $state('');
 	let bankProfileId = $state(profiles[0]?.id ?? '');
 	let ibanLast4 = $state('');
-	let currency = $state('EUR');
+	let currency = $state(PRIMARY_CURRENCY);
 	let submitting = $state(false);
 	let fieldError = $state<string | null>(null);
 
@@ -30,7 +30,7 @@
 		displayName = '';
 		bankProfileId = profiles[0]?.id ?? '';
 		ibanLast4 = '';
-		currency = 'EUR';
+		currency = PRIMARY_CURRENCY;
 		fieldError = null;
 	}
 

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -411,7 +411,9 @@
 							Opening balance
 						</p>
 						<div class="flex items-baseline gap-2 border-b-2 border-border pb-1.5">
-							<span class="text-2xl text-text-tertiary">{currency === PRIMARY_CURRENCY ? '€' : currency}</span>
+							<span class="text-2xl text-text-tertiary"
+								>{currency === PRIMARY_CURRENCY ? '€' : currency}</span
+							>
 							<input
 								type="text"
 								inputmode="decimal"
@@ -710,7 +712,11 @@
 																</p>
 															{/if}
 														</div>
-														<Amount value={candidate.amount} currency={PRIMARY_CURRENCY} size="sm" />
+														<Amount
+															value={candidate.amount}
+															currency={PRIMARY_CURRENCY}
+															size="sm"
+														/>
 													</button>
 												{/each}
 											</div>

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -12,6 +12,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import Amount from '$lib/components/Amount.svelte';
+	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 	interface Props {
 		open: boolean;
@@ -410,7 +411,7 @@
 							Opening balance
 						</p>
 						<div class="flex items-baseline gap-2 border-b-2 border-border pb-1.5">
-							<span class="text-2xl text-text-tertiary">{currency === 'EUR' ? '€' : currency}</span>
+							<span class="text-2xl text-text-tertiary">{currency === PRIMARY_CURRENCY ? '€' : currency}</span>
 							<input
 								type="text"
 								inputmode="decimal"
@@ -567,7 +568,7 @@
 													{conv.fromTransactionDescription}
 												</p>
 											</div>
-											<Amount value={-conv.fromAmount} currency="EUR" size="sm" />
+											<Amount value={-conv.fromAmount} currency={PRIMARY_CURRENCY} size="sm" />
 										</div>
 										<!-- Arrow -->
 										<div class="my-1.5 flex items-center gap-1.5 text-text-tertiary">
@@ -656,7 +657,7 @@
 												<p class="truncate text-xs font-medium text-text-primary">
 													{match.sourceAccountName} · {match.sourceDescription}
 												</p>
-												<Amount value={match.sourceAmount} currency="EUR" size="sm" />
+												<Amount value={match.sourceAmount} currency={PRIMARY_CURRENCY} size="sm" />
 											</div>
 											<div class="mt-1.5 flex items-center justify-between gap-2">
 												<p class="text-[11px] text-text-tertiary">No matching transfer found</p>
@@ -680,7 +681,7 @@
 														{match.sourceDescription}
 													</p>
 												</div>
-												<Amount value={match.sourceAmount} currency="EUR" size="sm" />
+												<Amount value={match.sourceAmount} currency={PRIMARY_CURRENCY} size="sm" />
 											</div>
 											<p
 												class="mb-1.5 text-[10px] font-semibold tracking-wider text-text-tertiary uppercase"
@@ -709,7 +710,7 @@
 																</p>
 															{/if}
 														</div>
-														<Amount value={candidate.amount} currency="EUR" size="sm" />
+														<Amount value={candidate.amount} currency={PRIMARY_CURRENCY} size="sm" />
 													</button>
 												{/each}
 											</div>

--- a/src/lib/components/ui/chart/chart-container.svelte
+++ b/src/lib/components/ui/chart/chart-container.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
-	import ChartStyle from "./chart-style.svelte";
-	import { setChartContext, type ChartConfig } from "./chart-utils.js";
+	import { cn, type WithElementRef } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import ChartStyle from './chart-style.svelte';
+	import { setChartContext, type ChartConfig } from './chart-utils.js';
 
 	const uid = $props.id();
 
@@ -17,12 +17,12 @@
 		config: ChartConfig;
 	} = $props();
 
-	const chartId = $derived(`chart-${id || uid.replace(/:/g, "")}`);
+	const chartId = $derived(`chart-${id || uid.replace(/:/g, '')}`);
 
 	setChartContext({
 		get config() {
 			return config;
-		},
+		}
 	});
 </script>
 
@@ -31,46 +31,46 @@
 	data-chart={chartId}
 	data-slot="chart"
 	class={cn(
-		"flex aspect-video justify-center overflow-visible text-xs",
+		'flex aspect-video justify-center overflow-visible text-xs',
 		// Overrides
 		//
 		// Stroke around dots/marks when hovering
-		"[&_.lc-highlight-point]:stroke-transparent",
+		'[&_.lc-highlight-point]:stroke-transparent',
 		// override the default stroke color of lines
-		"[&_.lc-line]:stroke-border/50",
+		'[&_.lc-line]:stroke-border/50',
 
 		// by default, layerchart shows a line intersecting the point when hovering, this hides that
-		"[&_.lc-highlight-line]:stroke-0",
+		'[&_.lc-highlight-line]:stroke-0',
 
 		// by default, when you hover a point on a stacked series chart, it will drop the opacity
 		// of the other series, this overrides that
-		"[&_.lc-area-path]:opacity-100 [&_.lc-highlight-line]:opacity-100 [&_.lc-highlight-point]:opacity-100 [&_.lc-spline-path]:opacity-100 [&_.lc-text]:text-xs [&_.lc-text-svg]:overflow-visible",
+		'[&_.lc-area-path]:opacity-100 [&_.lc-highlight-line]:opacity-100 [&_.lc-highlight-point]:opacity-100 [&_.lc-spline-path]:opacity-100 [&_.lc-text]:text-xs [&_.lc-text-svg]:overflow-visible',
 
 		// We don't want the little tick lines between the axis labels and the chart, so we remove
 		// the stroke. The alternative is to manually disable `tickMarks` on the x/y axis of every
 		// chart.
-		"[&_.lc-axis-tick]:stroke-0",
+		'[&_.lc-axis-tick]:stroke-0',
 
 		// We don't want to display the rule on the x/y axis, as there is already going to be
 		// a grid line there and rule ends up overlapping the marks because it is rendered after
 		// the marks
-		"[&_.lc-rule-x-line:not(.lc-grid-x-rule)]:stroke-0 [&_.lc-rule-y-line:not(.lc-grid-y-rule)]:stroke-0",
-		"[&_.lc-grid-x-radial-line]:stroke-border [&_.lc-grid-x-radial-circle]:stroke-border",
-		"[&_.lc-grid-y-radial-line]:stroke-border [&_.lc-grid-y-radial-circle]:stroke-border",
+		'[&_.lc-rule-x-line:not(.lc-grid-x-rule)]:stroke-0 [&_.lc-rule-y-line:not(.lc-grid-y-rule)]:stroke-0',
+		'[&_.lc-grid-x-radial-circle]:stroke-border [&_.lc-grid-x-radial-line]:stroke-border',
+		'[&_.lc-grid-y-radial-circle]:stroke-border [&_.lc-grid-y-radial-line]:stroke-border',
 
 		// Legend adjustments
-		"[&_.lc-legend-swatch-button]:items-center [&_.lc-legend-swatch-button]:gap-1.5",
-		"[&_.lc-legend-swatch-group]:items-center [&_.lc-legend-swatch-group]:gap-4",
-		"[&_.lc-legend-swatch]:size-2.5 [&_.lc-legend-swatch]:rounded-[2px]",
+		'[&_.lc-legend-swatch-button]:items-center [&_.lc-legend-swatch-button]:gap-1.5',
+		'[&_.lc-legend-swatch-group]:items-center [&_.lc-legend-swatch-group]:gap-4',
+		'[&_.lc-legend-swatch]:size-2.5 [&_.lc-legend-swatch]:rounded-[2px]',
 
 		// Labels
-		"[&_.lc-labels-text:not([fill])]:fill-foreground [&_text]:stroke-transparent",
+		'[&_.lc-labels-text:not([fill])]:fill-foreground [&_text]:stroke-transparent',
 
 		// Tick labels on th x/y axes
-		"[&_.lc-axis-tick-label]:fill-muted-foreground [&_.lc-axis-tick-label]:font-normal",
-		"[&_.lc-tooltip-rects-g]:fill-transparent",
-		"[&_.lc-layout-svg-g]:fill-transparent",
-		"[&_.lc-root-container]:w-full",
+		'[&_.lc-axis-tick-label]:fill-muted-foreground [&_.lc-axis-tick-label]:font-normal',
+		'[&_.lc-tooltip-rects-g]:fill-transparent',
+		'[&_.lc-layout-svg-g]:fill-transparent',
+		'[&_.lc-root-container]:w-full',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/chart/chart-container.svelte
+++ b/src/lib/components/ui/chart/chart-container.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import ChartStyle from "./chart-style.svelte";
+	import { setChartContext, type ChartConfig } from "./chart-utils.js";
+
+	const uid = $props.id();
+
+	let {
+		ref = $bindable(null),
+		id = uid,
+		class: className,
+		children,
+		config,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> & {
+		config: ChartConfig;
+	} = $props();
+
+	const chartId = $derived(`chart-${id || uid.replace(/:/g, "")}`);
+
+	setChartContext({
+		get config() {
+			return config;
+		},
+	});
+</script>
+
+<div
+	bind:this={ref}
+	data-chart={chartId}
+	data-slot="chart"
+	class={cn(
+		"flex aspect-video justify-center overflow-visible text-xs",
+		// Overrides
+		//
+		// Stroke around dots/marks when hovering
+		"[&_.lc-highlight-point]:stroke-transparent",
+		// override the default stroke color of lines
+		"[&_.lc-line]:stroke-border/50",
+
+		// by default, layerchart shows a line intersecting the point when hovering, this hides that
+		"[&_.lc-highlight-line]:stroke-0",
+
+		// by default, when you hover a point on a stacked series chart, it will drop the opacity
+		// of the other series, this overrides that
+		"[&_.lc-area-path]:opacity-100 [&_.lc-highlight-line]:opacity-100 [&_.lc-highlight-point]:opacity-100 [&_.lc-spline-path]:opacity-100 [&_.lc-text]:text-xs [&_.lc-text-svg]:overflow-visible",
+
+		// We don't want the little tick lines between the axis labels and the chart, so we remove
+		// the stroke. The alternative is to manually disable `tickMarks` on the x/y axis of every
+		// chart.
+		"[&_.lc-axis-tick]:stroke-0",
+
+		// We don't want to display the rule on the x/y axis, as there is already going to be
+		// a grid line there and rule ends up overlapping the marks because it is rendered after
+		// the marks
+		"[&_.lc-rule-x-line:not(.lc-grid-x-rule)]:stroke-0 [&_.lc-rule-y-line:not(.lc-grid-y-rule)]:stroke-0",
+		"[&_.lc-grid-x-radial-line]:stroke-border [&_.lc-grid-x-radial-circle]:stroke-border",
+		"[&_.lc-grid-y-radial-line]:stroke-border [&_.lc-grid-y-radial-circle]:stroke-border",
+
+		// Legend adjustments
+		"[&_.lc-legend-swatch-button]:items-center [&_.lc-legend-swatch-button]:gap-1.5",
+		"[&_.lc-legend-swatch-group]:items-center [&_.lc-legend-swatch-group]:gap-4",
+		"[&_.lc-legend-swatch]:size-2.5 [&_.lc-legend-swatch]:rounded-[2px]",
+
+		// Labels
+		"[&_.lc-labels-text:not([fill])]:fill-foreground [&_text]:stroke-transparent",
+
+		// Tick labels on th x/y axes
+		"[&_.lc-axis-tick-label]:fill-muted-foreground [&_.lc-axis-tick-label]:font-normal",
+		"[&_.lc-tooltip-rects-g]:fill-transparent",
+		"[&_.lc-layout-svg-g]:fill-transparent",
+		"[&_.lc-root-container]:w-full",
+		className
+	)}
+	{...restProps}
+>
+	<ChartStyle id={chartId} {config} />
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/chart/chart-style.svelte
+++ b/src/lib/components/ui/chart/chart-style.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { THEMES, type ChartConfig } from "./chart-utils.js";
+	import { THEMES, type ChartConfig } from './chart-utils.js';
 
 	let { id, config }: { id: string; config: ChartConfig } = $props();
 
@@ -19,18 +19,18 @@
 				return color ? `\t--color-${key}: ${color};` : null;
 			});
 
-			content += color.join("\n") + "\n}";
+			content += color.join('\n') + '\n}';
 
 			themeContents.push(content);
 		}
 
-		return themeContents.join("\n");
+		return themeContents.join('\n');
 	});
 </script>
 
 {#if themeContents}
 	{#key id}
-		<svelte:element this={"style"}>
+		<svelte:element this={'style'}>
 			{themeContents}
 		</svelte:element>
 	{/key}

--- a/src/lib/components/ui/chart/chart-style.svelte
+++ b/src/lib/components/ui/chart/chart-style.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { THEMES, type ChartConfig } from "./chart-utils.js";
+
+	let { id, config }: { id: string; config: ChartConfig } = $props();
+
+	const colorConfig = $derived(
+		config ? Object.entries(config).filter(([, config]) => config.theme || config.color) : null
+	);
+
+	const themeContents = $derived.by(() => {
+		if (!colorConfig || !colorConfig.length) return;
+
+		const themeContents = [];
+		for (const [_theme, prefix] of Object.entries(THEMES)) {
+			let content = `${prefix} [data-chart=${id}] {\n`;
+			const color = colorConfig.map(([key, itemConfig]) => {
+				const theme = _theme as keyof typeof itemConfig.theme;
+				const color = itemConfig.theme?.[theme] || itemConfig.color;
+				return color ? `\t--color-${key}: ${color};` : null;
+			});
+
+			content += color.join("\n") + "\n}";
+
+			themeContents.push(content);
+		}
+
+		return themeContents.join("\n");
+	});
+</script>
+
+{#if themeContents}
+	{#key id}
+		<svelte:element this={"style"}>
+			{themeContents}
+		</svelte:element>
+	{/key}
+{/if}

--- a/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+	import { getPayloadConfigFromPayload, useChart, type TooltipPayload } from "./chart-utils.js";
+	import { getChartContext, Tooltip as TooltipPrimitive } from "layerchart";
+	import type { Snippet } from "svelte";
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	function defaultFormatter(value: any, _payload: TooltipPayload[]) {
+		return `${value}`;
+	}
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		hideLabel = false,
+		indicator = "dot",
+		hideIndicator = false,
+		labelKey,
+		label,
+		labelFormatter = defaultFormatter,
+		labelClassName,
+		formatter,
+		nameKey,
+		color,
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> & {
+		hideLabel?: boolean;
+		label?: string;
+		indicator?: "line" | "dot" | "dashed";
+		nameKey?: string;
+		labelKey?: string;
+		hideIndicator?: boolean;
+		labelClassName?: string;
+		labelFormatter?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+			((value: any, payload: TooltipPayload[]) => string | number | Snippet) | null;
+		formatter?: Snippet<
+			[
+				{
+					value: unknown;
+					name: string;
+					item: TooltipPayload;
+					index: number;
+					payload: TooltipPayload[];
+				},
+			]
+		>;
+	} = $props();
+
+	const chart = useChart();
+	const chartCtx = getChartContext();
+
+	// Filter to series with defined values (important for item-based charts like Pie/Arc
+	// where only the hovered item has a value)
+	const visibleSeries = $derived(
+		chartCtx.tooltip.series.filter((s: TooltipPayload) => s.value !== undefined)
+	);
+
+	const formattedLabel = $derived.by(() => {
+		if (hideLabel || !visibleSeries?.length) return null;
+
+		const [item] = visibleSeries;
+		const tooltipData = chartCtx.tooltip.data;
+
+		// Get the x-axis label value from the raw tooltip data (e.g. a Date or month string)
+		const dataLabel = tooltipData != null ? chartCtx.x(tooltipData) : undefined;
+
+		const key = labelKey ?? item?.label ?? item?.key ?? "value";
+		const itemConfig = getPayloadConfigFromPayload(
+			chart.config,
+			item,
+			key,
+			tooltipData as Record<string, unknown> | null
+		);
+
+		let value: unknown;
+		if (!labelKey && typeof label === "string") {
+			value = chart.config[label as keyof typeof chart.config]?.label ?? label;
+		} else if (labelKey) {
+			value = itemConfig?.label ?? dataLabel;
+		} else {
+			value = dataLabel;
+		}
+
+		if (value === undefined) return null;
+		if (!labelFormatter) return value;
+		return labelFormatter(value, visibleSeries);
+	});
+
+	const nestLabel = $derived(visibleSeries.length === 1 && indicator !== "dot");
+</script>
+
+{#snippet TooltipLabel()}
+	{#if formattedLabel}
+		<div class={cn("font-medium", labelClassName)}>
+			{#if typeof formattedLabel === "function"}
+				{@render formattedLabel()}
+			{:else}
+				{formattedLabel}
+			{/if}
+		</div>
+	{/if}
+{/snippet}
+
+<TooltipPrimitive.Root variant="none">
+	<div
+		bind:this={ref}
+		class={cn(
+			"border-border/50 bg-background grid min-w-[9rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+			className
+		)}
+		{...restProps}
+	>
+		{#if !nestLabel}
+			{@render TooltipLabel()}
+		{/if}
+		<div class="grid gap-1.5">
+			{#each visibleSeries as item, i (item.key + i)}
+				{@const key = `${nameKey || item.key || item.label || "value"}`}
+				{@const itemConfig = getPayloadConfigFromPayload(
+					chart.config,
+					item,
+					key,
+					chartCtx.tooltip.data
+				)}
+				{@const indicatorColor = color || item.config?.color || item.color}
+				<div
+					class={cn(
+						"[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:size-2.5",
+						indicator === "dot" && "items-center"
+					)}
+				>
+					{#if formatter && item.value !== undefined && item.label}
+						{@render formatter({
+							value: item.value,
+							name: item.label,
+							item,
+							index: i,
+							payload: visibleSeries,
+						})}
+					{:else}
+						{#if itemConfig?.icon}
+							<itemConfig.icon />
+						{:else if !hideIndicator}
+							<div
+								style="--color-bg: {indicatorColor}; --color-border: {indicatorColor};"
+								class={cn(
+									"shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+									{
+										"size-2.5": indicator === "dot",
+										"h-full w-1": indicator === "line",
+										"w-0 border-[1.5px] border-dashed bg-transparent":
+											indicator === "dashed",
+										"my-0.5": nestLabel && indicator === "dashed",
+									}
+								)}
+							></div>
+						{/if}
+						<div
+							class={cn(
+								"flex flex-1 shrink-0 justify-between leading-none",
+								nestLabel ? "items-end" : "items-center"
+							)}
+						>
+							<div class="grid gap-1.5">
+								{#if nestLabel}
+									{@render TooltipLabel()}
+								{/if}
+								<span class="text-muted-foreground">
+									{itemConfig?.label || item.label}
+								</span>
+							</div>
+							{#if item.value !== undefined}
+								<span class="text-foreground font-mono font-medium tabular-nums">
+									{item.value.toLocaleString()}
+								</span>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</div>
+</TooltipPrimitive.Root>

--- a/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
-	import { getPayloadConfigFromPayload, useChart, type TooltipPayload } from "./chart-utils.js";
-	import { getChartContext, Tooltip as TooltipPrimitive } from "layerchart";
-	import type { Snippet } from "svelte";
+	import { cn, type WithElementRef, type WithoutChildren } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { getPayloadConfigFromPayload, useChart, type TooltipPayload } from './chart-utils.js';
+	import { getChartContext, Tooltip as TooltipPrimitive } from 'layerchart';
+	import type { Snippet } from 'svelte';
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	function defaultFormatter(value: any, _payload: TooltipPayload[]) {
@@ -14,7 +14,7 @@
 		ref = $bindable(null),
 		class: className,
 		hideLabel = false,
-		indicator = "dot",
+		indicator = 'dot',
 		hideIndicator = false,
 		labelKey,
 		label,
@@ -27,7 +27,7 @@
 	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> & {
 		hideLabel?: boolean;
 		label?: string;
-		indicator?: "line" | "dot" | "dashed";
+		indicator?: 'line' | 'dot' | 'dashed';
 		nameKey?: string;
 		labelKey?: string;
 		hideIndicator?: boolean;
@@ -42,7 +42,7 @@
 					item: TooltipPayload;
 					index: number;
 					payload: TooltipPayload[];
-				},
+				}
 			]
 		>;
 	} = $props();
@@ -65,7 +65,7 @@
 		// Get the x-axis label value from the raw tooltip data (e.g. a Date or month string)
 		const dataLabel = tooltipData != null ? chartCtx.x(tooltipData) : undefined;
 
-		const key = labelKey ?? item?.label ?? item?.key ?? "value";
+		const key = labelKey ?? item?.label ?? item?.key ?? 'value';
 		const itemConfig = getPayloadConfigFromPayload(
 			chart.config,
 			item,
@@ -74,7 +74,7 @@
 		);
 
 		let value: unknown;
-		if (!labelKey && typeof label === "string") {
+		if (!labelKey && typeof label === 'string') {
 			value = chart.config[label as keyof typeof chart.config]?.label ?? label;
 		} else if (labelKey) {
 			value = itemConfig?.label ?? dataLabel;
@@ -87,13 +87,13 @@
 		return labelFormatter(value, visibleSeries);
 	});
 
-	const nestLabel = $derived(visibleSeries.length === 1 && indicator !== "dot");
+	const nestLabel = $derived(visibleSeries.length === 1 && indicator !== 'dot');
 </script>
 
 {#snippet TooltipLabel()}
 	{#if formattedLabel}
-		<div class={cn("font-medium", labelClassName)}>
-			{#if typeof formattedLabel === "function"}
+		<div class={cn('font-medium', labelClassName)}>
+			{#if typeof formattedLabel === 'function'}
 				{@render formattedLabel()}
 			{:else}
 				{formattedLabel}
@@ -106,7 +106,7 @@
 	<div
 		bind:this={ref}
 		class={cn(
-			"border-border/50 bg-background grid min-w-[9rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+			'grid min-w-[9rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl',
 			className
 		)}
 		{...restProps}
@@ -116,7 +116,7 @@
 		{/if}
 		<div class="grid gap-1.5">
 			{#each visibleSeries as item, i (item.key + i)}
-				{@const key = `${nameKey || item.key || item.label || "value"}`}
+				{@const key = `${nameKey || item.key || item.label || 'value'}`}
 				{@const itemConfig = getPayloadConfigFromPayload(
 					chart.config,
 					item,
@@ -126,8 +126,8 @@
 				{@const indicatorColor = color || item.config?.color || item.color}
 				<div
 					class={cn(
-						"[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:size-2.5",
-						indicator === "dot" && "items-center"
+						'flex w-full flex-wrap items-stretch gap-2 [&>svg]:size-2.5 [&>svg]:text-muted-foreground',
+						indicator === 'dot' && 'items-center'
 					)}
 				>
 					{#if formatter && item.value !== undefined && item.label}
@@ -136,7 +136,7 @@
 							name: item.label,
 							item,
 							index: i,
-							payload: visibleSeries,
+							payload: visibleSeries
 						})}
 					{:else}
 						{#if itemConfig?.icon}
@@ -144,22 +144,18 @@
 						{:else if !hideIndicator}
 							<div
 								style="--color-bg: {indicatorColor}; --color-border: {indicatorColor};"
-								class={cn(
-									"shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
-									{
-										"size-2.5": indicator === "dot",
-										"h-full w-1": indicator === "line",
-										"w-0 border-[1.5px] border-dashed bg-transparent":
-											indicator === "dashed",
-										"my-0.5": nestLabel && indicator === "dashed",
-									}
-								)}
+								class={cn('shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)', {
+									'size-2.5': indicator === 'dot',
+									'h-full w-1': indicator === 'line',
+									'w-0 border-[1.5px] border-dashed bg-transparent': indicator === 'dashed',
+									'my-0.5': nestLabel && indicator === 'dashed'
+								})}
 							></div>
 						{/if}
 						<div
 							class={cn(
-								"flex flex-1 shrink-0 justify-between leading-none",
-								nestLabel ? "items-end" : "items-center"
+								'flex flex-1 shrink-0 justify-between leading-none',
+								nestLabel ? 'items-end' : 'items-center'
 							)}
 						>
 							<div class="grid gap-1.5">
@@ -171,7 +167,7 @@
 								</span>
 							</div>
 							{#if item.value !== undefined}
-								<span class="text-foreground font-mono font-medium tabular-nums">
+								<span class="font-mono font-medium text-foreground tabular-nums">
 									{item.value.toLocaleString()}
 								</span>
 							{/if}

--- a/src/lib/components/ui/chart/chart-utils.ts
+++ b/src/lib/components/ui/chart/chart-utils.ts
@@ -1,0 +1,68 @@
+import type { Tooltip } from "layerchart";
+import { getContext, setContext, type Component, type Snippet } from "svelte";
+
+export const THEMES = { light: "", dark: ".dark" } as const;
+
+export type ChartConfig = {
+	[k in string]: {
+		label?: string;
+		icon?: Component;
+	} & (
+		| { color?: string; theme?: never }
+		| { color?: never; theme: Record<keyof typeof THEMES, string> }
+	);
+};
+
+export type ExtractSnippetParams<T> = T extends Snippet<[infer P]> ? P : never;
+
+export type TooltipPayload = Tooltip.TooltipSeries;
+
+// Helper to extract item config from a payload.
+export function getPayloadConfigFromPayload(
+	config: ChartConfig,
+	payload: TooltipPayload,
+	key: string,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	data?: Record<string, any> | null
+) {
+	if (typeof payload !== "object" || payload === null) return undefined;
+
+	const payloadConfig =
+		"config" in payload && typeof payload.config === "object" && payload.config !== null
+			? payload.config
+			: undefined;
+
+	let configLabelKey: string = key;
+
+	if (payload.key === key) {
+		configLabelKey = payload.key;
+	} else if (payload.label === key) {
+		configLabelKey = payload.label;
+	} else if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+		configLabelKey = payload[key as keyof typeof payload] as string;
+	} else if (
+		payloadConfig !== undefined &&
+		key in payloadConfig &&
+		typeof payloadConfig[key as keyof typeof payloadConfig] === "string"
+	) {
+		configLabelKey = payloadConfig[key as keyof typeof payloadConfig] as string;
+	} else if (data != null && key in data && typeof data[key] === "string") {
+		configLabelKey = data[key] as string;
+	}
+
+	return configLabelKey in config ? config[configLabelKey] : config[key as keyof typeof config];
+}
+
+type ChartContextValue = {
+	config: ChartConfig;
+};
+
+const chartContextKey = Symbol("chart-context");
+
+export function setChartContext(value: ChartContextValue) {
+	return setContext(chartContextKey, value);
+}
+
+export function useChart() {
+	return getContext<ChartContextValue>(chartContextKey);
+}

--- a/src/lib/components/ui/chart/chart-utils.ts
+++ b/src/lib/components/ui/chart/chart-utils.ts
@@ -1,7 +1,7 @@
-import type { Tooltip } from "layerchart";
-import { getContext, setContext, type Component, type Snippet } from "svelte";
+import type { Tooltip } from 'layerchart';
+import { getContext, setContext, type Component, type Snippet } from 'svelte';
 
-export const THEMES = { light: "", dark: ".dark" } as const;
+export const THEMES = { light: '', dark: '.dark' } as const;
 
 export type ChartConfig = {
 	[k in string]: {
@@ -25,10 +25,10 @@ export function getPayloadConfigFromPayload(
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	data?: Record<string, any> | null
 ) {
-	if (typeof payload !== "object" || payload === null) return undefined;
+	if (typeof payload !== 'object' || payload === null) return undefined;
 
 	const payloadConfig =
-		"config" in payload && typeof payload.config === "object" && payload.config !== null
+		'config' in payload && typeof payload.config === 'object' && payload.config !== null
 			? payload.config
 			: undefined;
 
@@ -38,15 +38,15 @@ export function getPayloadConfigFromPayload(
 		configLabelKey = payload.key;
 	} else if (payload.label === key) {
 		configLabelKey = payload.label;
-	} else if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+	} else if (key in payload && typeof payload[key as keyof typeof payload] === 'string') {
 		configLabelKey = payload[key as keyof typeof payload] as string;
 	} else if (
 		payloadConfig !== undefined &&
 		key in payloadConfig &&
-		typeof payloadConfig[key as keyof typeof payloadConfig] === "string"
+		typeof payloadConfig[key as keyof typeof payloadConfig] === 'string'
 	) {
 		configLabelKey = payloadConfig[key as keyof typeof payloadConfig] as string;
-	} else if (data != null && key in data && typeof data[key] === "string") {
+	} else if (data != null && key in data && typeof data[key] === 'string') {
 		configLabelKey = data[key] as string;
 	}
 
@@ -57,7 +57,7 @@ type ChartContextValue = {
 	config: ChartConfig;
 };
 
-const chartContextKey = Symbol("chart-context");
+const chartContextKey = Symbol('chart-context');
 
 export function setChartContext(value: ChartContextValue) {
 	return setContext(chartContextKey, value);

--- a/src/lib/components/ui/chart/index.ts
+++ b/src/lib/components/ui/chart/index.ts
@@ -1,6 +1,6 @@
-import ChartContainer from "./chart-container.svelte";
-import ChartTooltip from "./chart-tooltip.svelte";
+import ChartContainer from './chart-container.svelte';
+import ChartTooltip from './chart-tooltip.svelte';
 
-export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
+export { getPayloadConfigFromPayload, type ChartConfig } from './chart-utils.js';
 
 export { ChartContainer, ChartTooltip, ChartContainer as Container, ChartTooltip as Tooltip };

--- a/src/lib/components/ui/chart/index.ts
+++ b/src/lib/components/ui/chart/index.ts
@@ -1,0 +1,6 @@
+import ChartContainer from "./chart-container.svelte";
+import ChartTooltip from "./chart-tooltip.svelte";
+
+export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
+
+export { ChartContainer, ChartTooltip, ChartContainer as Container, ChartTooltip as Tooltip };

--- a/src/lib/currencies.ts
+++ b/src/lib/currencies.ts
@@ -1,3 +1,10 @@
+/**
+ * The workspace's primary (home) currency.
+ * All dashboards, totals, and charts are expressed in this currency.
+ * In a future version this will be a per-workspace setting; for now it is fixed.
+ */
+export const PRIMARY_CURRENCY = 'EUR';
+
 /** Supported currencies with their display labels. */
 export const CURRENCIES: { code: string; label: string }[] = [
 	{ code: 'EUR', label: 'EUR — Euro' },

--- a/src/lib/server/balance.ts
+++ b/src/lib/server/balance.ts
@@ -1,6 +1,7 @@
 import { eq, sql } from 'drizzle-orm';
 import { db } from './db/index.js';
 import { transactions, bankAccounts } from './db/schema.js';
+import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 /**
  * Compute the synthetic opening balance needed so that:
@@ -50,7 +51,7 @@ export async function upsertOpeningBalance(
 			bankAccountId,
 			accountingDate: openingDate,
 			amount: openingAmount.toFixed(4),
-			currency: 'EUR',
+			currency: PRIMARY_CURRENCY,
 			description: 'Opening balance',
 			notes:
 				'This represents the opening status of the bank account in order to reconcile the balance with the ledger.',

--- a/src/lib/server/currency-converter.ts
+++ b/src/lib/server/currency-converter.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 import { addDays, subDays } from 'date-fns';
 import { db } from './db/index.js';
 import { bankAccounts, currencyConversions, transactions } from './db/schema.js';
+import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 /**
  * Converts a Date (or Drizzle date result) to a plain `YYYY-MM-DD` string.
@@ -51,7 +52,7 @@ export async function detectAndCreateConversions(
 
 	const results: CurrencyConversionResult[] = [];
 
-	if (accountCurrency !== 'EUR') {
+	if (accountCurrency !== PRIMARY_CURRENCY) {
 		// Flow 1: new non-EUR transactions → find matching negative EUR transactions
 		const fxTxs = await db
 			.select({
@@ -92,7 +93,7 @@ export async function detectAndCreateConversions(
 				.where(
 					and(
 						eq(bankAccounts.workspaceId, workspaceId),
-						eq(bankAccounts.currency, 'EUR'),
+						eq(bankAccounts.currency, PRIMARY_CURRENCY),
 						sql`${transactions.amount}::numeric < 0`,
 						eq(transactions.isFxCandidate, true),
 						// EUR outgoing must be ≤ FX settlement date, within 3 days
@@ -190,7 +191,7 @@ export async function detectAndCreateConversions(
 				.where(
 					and(
 						eq(bankAccounts.workspaceId, workspaceId),
-						ne(bankAccounts.currency, 'EUR'),
+						ne(bankAccounts.currency, PRIMARY_CURRENCY),
 						sql`${transactions.amount}::numeric > 0`,
 						eq(transactions.isFxCandidate, true),
 						isNull(transactions.conversionId),
@@ -324,7 +325,7 @@ export async function countUnresolvedFxTransactions(workspaceId: string): Promis
 		.where(
 			and(
 				eq(bankAccounts.workspaceId, workspaceId),
-				ne(bankAccounts.currency, 'EUR'),
+				ne(bankAccounts.currency, PRIMARY_CURRENCY),
 				isNull(transactions.conversionId),
 				eq(transactions.isOpeningBalance, false)
 			)
@@ -361,7 +362,7 @@ export async function getUnresolvedFxAccounts(workspaceId: string): Promise<Unre
 		.where(
 			and(
 				eq(bankAccounts.workspaceId, workspaceId),
-				ne(bankAccounts.currency, 'EUR'),
+				ne(bankAccounts.currency, PRIMARY_CURRENCY),
 				isNull(transactions.conversionId),
 				eq(transactions.isOpeningBalance, false)
 			)

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -55,8 +55,7 @@ export async function queryRollingBalance(
 
 	// safe — granularity is a validated union type, never user-controlled input
 	const unit = sql.raw(`'${granularity}'`);
-	const bucketExpr =
-		sql<string>`DATE_TRUNC(${unit}, ${transactions.accountingDate}::timestamp)::date::text`;
+	const bucketExpr = sql<string>`DATE_TRUNC(${unit}, ${transactions.accountingDate}::timestamp)::date::text`;
 
 	const buckets = await db
 		.select({

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, gte, ilike, inArray, sql } from 'drizzle-orm';
 import { db } from './index.js';
 import { transactions, bankAccounts } from './schema.js';
+import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 export const TX_PAGE_SIZE = 25;
 
@@ -60,7 +61,7 @@ export async function queryRollingBalance(
 	const buckets = await db
 		.select({
 			bucket: bucketExpr,
-			netChange: sql<string>`SUM(CASE WHEN ${transactions.currency} = 'EUR' THEN ${transactions.amount}::numeric ELSE ${transactions.amountEur}::numeric END)`
+			netChange: sql<string>`SUM(CASE WHEN ${transactions.currency} = ${PRIMARY_CURRENCY} THEN ${transactions.amount}::numeric ELSE ${transactions.amountEur}::numeric END)`
 		})
 		.from(transactions)
 		.where(
@@ -230,7 +231,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 			...r,
 			amount: parseFloat(r.amount as string),
 			amountEur:
-				r.currency === 'EUR'
+				r.currency === PRIMARY_CURRENCY
 					? parseFloat(r.amount as string)
 					: r.amountEur != null
 						? parseFloat(r.amountEur as string)

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -60,7 +60,7 @@ export async function queryRollingBalance(
 	const buckets = await db
 		.select({
 			bucket: bucketExpr,
-			netChange: sql<string>`SUM(COALESCE(${transactions.amountEur}, ${transactions.amount})::numeric)`
+			netChange: sql<string>`SUM(CASE WHEN ${transactions.currency} = 'EUR' THEN ${transactions.amount}::numeric ELSE ${transactions.amountEur}::numeric END)`
 		})
 		.from(transactions)
 		.where(

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -1,8 +1,93 @@
-import { and, desc, eq, ilike, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, sql } from 'drizzle-orm';
 import { db } from './index.js';
 import { transactions, bankAccounts } from './schema.js';
 
 export const TX_PAGE_SIZE = 25;
+
+// ---------------------------------------------------------------------------
+// Rolling balance query
+// ---------------------------------------------------------------------------
+
+export type Granularity = 'week' | 'month' | 'quarter';
+
+export interface BalancePoint {
+	bucket: string; // ISO date string — start of the period bucket
+	netChange: number;
+	cumulativeBalance: number;
+}
+
+export interface RollingBalanceResult {
+	points: BalancePoint[];
+	windowStart: string; // ISO string — serialisable across SSR boundary
+	windowEnd: string;
+}
+
+export async function queryRollingBalance(
+	accessibleIds: string[],
+	granularity: Granularity = 'month'
+): Promise<RollingBalanceResult> {
+	const now = new Date();
+	const windowEnd = now.toISOString();
+
+	const threeMonthsAgo = new Date(now);
+	threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+
+	// Find the earliest posted non-transfer non-opening-balance transaction
+	const [earliest] = await db
+		.select({ minDate: sql<string>`MIN(${transactions.accountingDate})::text` })
+		.from(transactions)
+		.where(
+			and(
+				inArray(transactions.bankAccountId, accessibleIds),
+				eq(transactions.isTransfer, false),
+				eq(transactions.isOpeningBalance, false),
+				eq(transactions.status, 'posted')
+			)
+		);
+
+	if (!earliest?.minDate) {
+		return { points: [], windowStart: threeMonthsAgo.toISOString(), windowEnd };
+	}
+
+	const earliestDate = new Date(earliest.minDate);
+	const windowStart = earliestDate < threeMonthsAgo ? threeMonthsAgo : earliestDate;
+
+	// safe — granularity is a validated union type, never user-controlled input
+	const unit = sql.raw(`'${granularity}'`);
+	const bucketExpr =
+		sql<string>`DATE_TRUNC(${unit}, ${transactions.accountingDate}::timestamp)::date::text`;
+
+	const buckets = await db
+		.select({
+			bucket: bucketExpr,
+			netChange: sql<string>`SUM(COALESCE(${transactions.amountEur}, ${transactions.amount})::numeric)`
+		})
+		.from(transactions)
+		.where(
+			and(
+				inArray(transactions.bankAccountId, accessibleIds),
+				eq(transactions.isTransfer, false),
+				eq(transactions.isOpeningBalance, false),
+				eq(transactions.status, 'posted'),
+				gte(transactions.accountingDate, windowStart)
+			)
+		)
+		.groupBy(bucketExpr)
+		.orderBy(bucketExpr);
+
+	// Compute running cumulative sum in JS — dataset is tiny (≤52 weekly buckets)
+	let running = 0;
+	const points: BalancePoint[] = buckets.map((b) => {
+		running += parseFloat(b.netChange ?? '0');
+		return {
+			bucket: b.bucket,
+			netChange: parseFloat(b.netChange ?? '0'),
+			cumulativeBalance: running
+		};
+	});
+
+	return { points, windowStart: windowStart.toISOString(), windowEnd };
+}
 
 export type TxFilter = 'all' | 'expenses' | 'transfers' | 'review';
 

--- a/src/lib/server/parsers/normalizer.ts
+++ b/src/lib/server/parsers/normalizer.ts
@@ -78,9 +78,13 @@ export function normalizeRow(
 		accountingDate,
 		valueDate,
 		amount,
-		currency: profile.currencyColumn ? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY : PRIMARY_CURRENCY,
+		currency: profile.currencyColumn
+			? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY
+			: PRIMARY_CURRENCY,
 		amountOriginal: localAmount ?? amount,
-		currencyOriginal: profile.currencyColumn ? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY : PRIMARY_CURRENCY,
+		currencyOriginal: profile.currencyColumn
+			? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY
+			: PRIMARY_CURRENCY,
 		description: raw[profile.descriptionColumn]?.trim() ?? '',
 		runningBalance,
 		status,

--- a/src/lib/server/parsers/normalizer.ts
+++ b/src/lib/server/parsers/normalizer.ts
@@ -1,6 +1,7 @@
 import { parse as parseDate, isValid } from 'date-fns';
 import type { BankParserProfile, NormalizedTransaction } from './types.js';
 import { SEMANTIC_SYNONYMS } from './detector.js';
+import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 // ─── Optional column synonym lists (re-exported from detector for backward compat) ──
 
@@ -77,9 +78,9 @@ export function normalizeRow(
 		accountingDate,
 		valueDate,
 		amount,
-		currency: profile.currencyColumn ? raw[profile.currencyColumn]?.trim() || 'EUR' : 'EUR',
+		currency: profile.currencyColumn ? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY : PRIMARY_CURRENCY,
 		amountOriginal: localAmount ?? amount,
-		currencyOriginal: profile.currencyColumn ? raw[profile.currencyColumn]?.trim() || 'EUR' : 'EUR',
+		currencyOriginal: profile.currencyColumn ? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY : PRIMARY_CURRENCY,
 		description: raw[profile.descriptionColumn]?.trim() ?? '',
 		runningBalance,
 		status,

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -4,11 +4,21 @@ import type { PageServerLoad } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts, csvUploads, transactions } from '$lib/server/db/schema.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
+import { queryRollingBalance, type Granularity } from '$lib/server/db/queries.js';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
 	if (!locals.user) error(401);
 
 	const accessibleIds = await getAccessibleAccountIds(locals.user.id);
+
+	const gParam = url.searchParams.get('g') ?? 'month';
+	const granularity: Granularity = (['week', 'month', 'quarter'] as const).includes(
+		gParam as Granularity
+	)
+		? (gParam as Granularity)
+		: 'month';
+
+	const emptyBalance = { points: [], windowStart: '', windowEnd: '' };
 
 	if (accessibleIds.length === 0) {
 		return {
@@ -25,14 +35,16 @@ export const load: PageServerLoad = async ({ locals }) => {
 				txCount: number;
 				lastUploadedAt: Date | null;
 			}[],
-			trendPercent: null as number | null
+			trendPercent: null as number | null,
+			balanceData: emptyBalance,
+			granularity
 		};
 	}
 
 	const thirtyDaysAgo = new Date();
 	thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
-	const [rows, recentSums] = await Promise.all([
+	const [rows, recentSums, balanceData] = await Promise.all([
 		db
 			.select({
 				id: bankAccounts.id,
@@ -71,7 +83,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 					eq(transactions.isOpeningBalance, false)
 				)
 			)
-			.groupBy(transactions.bankAccountId)
+			.groupBy(transactions.bankAccountId),
+
+		queryRollingBalance(accessibleIds, granularity)
 	]);
 
 	const netChangeMap = new Map(
@@ -100,6 +114,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 	return {
 		user: locals.user,
 		accounts,
-		trendPercent
+		trendPercent,
+		balanceData,
+		granularity
 	};
 };

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -11,7 +11,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { TrendingUp, TrendingDown, Plus, Clock, MoreHorizontal, Landmark } from '@lucide/svelte';
+	import { TrendingUp, TrendingDown, Plus, Clock, MoreHorizontal, Landmark, BarChart2 } from '@lucide/svelte';
 	import type { PageData } from './$types';
 	import type { Granularity } from '$lib/server/db/queries.js';
 
@@ -85,26 +85,42 @@
 	</div>
 
 	<!-- Rolling balance chart -->
-	{#if data.balanceData.points.length > 0}
-		<div class="mb-10">
-			<Card.Root class="gap-2 border-border bg-surface px-2 py-4 shadow-sm">
-				<Card.Header class="flex flex-row items-center gap-2 space-y-0 border-b">
-					<div class="grid flex-1 gap-1 text-start">
-						<Card.Title>Rolling Balance</Card.Title>
-						<Card.Description>Showing the last 3 months</Card.Description>
-					</div>
+	<div class="mb-10">
+		<Card.Root class="gap-2 border-border bg-surface px-2 py-4 shadow-sm">
+			<Card.Header class="flex flex-row items-center gap-2 space-y-0 border-b">
+				<div class="grid flex-1 gap-1 text-start">
+					<Card.Title>Rolling Balance</Card.Title>
+					<Card.Description>Showing the last 3 months</Card.Description>
+				</div>
+				{#if data.balanceData.points.length > 0}
 					<GranularitySelector value={data.granularity} onchange={setGranularity} />
-				</Card.Header>
-				<Card.Content>
+				{/if}
+			</Card.Header>
+			<Card.Content>
+				{#if data.balanceData.points.length > 0}
 					<BalanceChart
 						points={data.balanceData.points}
 						{projectedPoints}
 						granularity={data.granularity}
 					/>
-				</Card.Content>
-			</Card.Root>
-		</div>
-	{/if}
+				{:else}
+					<div class="flex h-56 flex-col items-center justify-center gap-3 text-center md:h-64">
+						<div
+							class="flex h-12 w-12 items-center justify-center rounded-full bg-surface-sunken text-text-tertiary"
+						>
+							<BarChart2 size={22} />
+						</div>
+						<div>
+							<p class="text-sm font-medium text-text-primary">No data yet</p>
+							<p class="mt-0.5 text-sm text-text-secondary">
+								Upload your first bank statement to see your balance history.
+							</p>
+						</div>
+					</div>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+	</div>
 
 	<!-- Section heading -->
 	<div class="mb-4 flex items-center justify-between">

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
 	import { formatDistanceToNow } from 'date-fns';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
+	import { buildProjection } from '$lib/chart-utils.js';
 	import Amount from '$lib/components/Amount.svelte';
 	import BankLogo from '$lib/components/BankLogo.svelte';
+	import BalanceChart from '$lib/components/BalanceChart.svelte';
+	import GranularitySelector from '$lib/components/GranularitySelector.svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { TrendingUp, TrendingDown, Plus, Clock, MoreHorizontal, Landmark } from '@lucide/svelte';
 	import type { PageData } from './$types';
+	import type { Granularity } from '$lib/server/db/queries.js';
 
 	let { data }: { data: PageData } = $props();
 
@@ -22,6 +28,14 @@
 	);
 
 	const firstName = $derived(data.user.name.split(' ')[0]);
+
+	const projectedPoints = $derived(buildProjection(data.balanceData.points, data.granularity));
+
+	function setGranularity(g: Granularity) {
+		const url = new URL(page.url.href);
+		url.searchParams.set('g', g);
+		goto(url.toString(), { keepFocus: true, replaceState: true });
+	}
 
 	function formatLastUpdated(date: Date | string | null): string {
 		if (!date) return 'No uploads yet';
@@ -69,6 +83,27 @@
 			{/if}
 		</div>
 	</div>
+
+	<!-- Rolling balance chart -->
+	{#if data.balanceData.points.length > 0}
+		<div class="mb-10">
+			<div class="mb-4 flex items-center justify-between">
+				<p class="text-xs font-semibold tracking-widest text-text-tertiary uppercase">
+					Rolling Balance
+				</p>
+				<GranularitySelector value={data.granularity} onchange={setGranularity} />
+			</div>
+			<Card.Root class="border-border bg-surface shadow-sm">
+				<Card.Content class="px-4 pt-4 pb-2">
+					<BalanceChart
+						points={data.balanceData.points}
+						{projectedPoints}
+						granularity={data.granularity}
+					/>
+				</Card.Content>
+			</Card.Root>
+		</div>
+	{/if}
 
 	<!-- Section heading -->
 	<div class="mb-4 flex items-center justify-between">

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { formatDistanceToNow } from 'date-fns';
+	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 	import Amount from '$lib/components/Amount.svelte';
 	import BankLogo from '$lib/components/BankLogo.svelte';
 	import { Badge } from '$lib/components/ui/badge';
@@ -15,7 +16,7 @@
 	const formattedTotal = $derived(
 		new Intl.NumberFormat('es-ES', {
 			style: 'currency',
-			currency: 'EUR',
+			currency: PRIMARY_CURRENCY,
 			minimumFractionDigits: 2
 		}).format(totalBalance)
 	);

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -87,14 +87,15 @@
 	<!-- Rolling balance chart -->
 	{#if data.balanceData.points.length > 0}
 		<div class="mb-10">
-			<div class="mb-4 flex items-center justify-between">
-				<p class="text-xs font-semibold tracking-widest text-text-tertiary uppercase">
-					Rolling Balance
-				</p>
-				<GranularitySelector value={data.granularity} onchange={setGranularity} />
-			</div>
-			<Card.Root class="border-border bg-surface shadow-sm">
-				<Card.Content class="px-4 pt-4 pb-2">
+			<Card.Root class="gap-2 border-border bg-surface px-2 py-4 shadow-sm">
+				<Card.Header class="flex flex-row items-center gap-2 space-y-0 border-b">
+					<div class="grid flex-1 gap-1 text-start">
+						<Card.Title>Rolling Balance</Card.Title>
+						<Card.Description>Showing the last 3 months</Card.Description>
+					</div>
+					<GranularitySelector value={data.granularity} onchange={setGranularity} />
+				</Card.Header>
+				<Card.Content>
 					<BalanceChart
 						points={data.balanceData.points}
 						{projectedPoints}

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -15,6 +15,7 @@
 		CircleAlert
 	} from '@lucide/svelte';
 	import Amount from '$lib/components/Amount.svelte';
+	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button, buttonVariants } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
@@ -161,7 +162,7 @@
 
 		<!-- Main KPIs -->
 		<div class="flex items-start gap-4 pt-4">
-			<Amount value={totalBalance} currency={'EUR'} size="lg" />
+			<Amount value={totalBalance} currency={PRIMARY_CURRENCY} size="lg" />
 		</div>
 	</div>
 
@@ -422,12 +423,12 @@
 									<!-- Amount col -->
 									<td class="px-2 py-2 text-right md:px-4 md:py-3">
 										<Amount value={tx.amount} currency={tx.currency} size="xs" class="md:text-sm" />
-										{#if tx.currency !== 'EUR'}
+										{#if tx.currency !== PRIMARY_CURRENCY}
 											{#if tx.amountEur != null}
 												<div class="mt-0.5 text-text-tertiary">
 													<Amount
 														value={tx.amountEur}
-														currency="EUR"
+														currency={PRIMARY_CURRENCY}
 														size="xs"
 														class="text-[10px] md:text-xs"
 														colorize={false}

--- a/src/routes/api/accounts/+server.ts
+++ b/src/routes/api/accounts/+server.ts
@@ -6,7 +6,7 @@ import { bankAccounts, csvUploads, transactions } from '$lib/server/db/schema.js
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
 import { getAllProfiles } from '$lib/server/parsers/index.js';
 
-import { CURRENCY_CODES } from '$lib/currencies.js';
+import { CURRENCY_CODES, PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 const VALID_PROFILE_IDS = new Set(getAllProfiles().map((p) => p.bankProfileId));
 const VALID_CURRENCIES = new Set(CURRENCY_CODES);
@@ -63,7 +63,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user.workspaceId) throw error(403, 'No workspace — run the seed script first');
 
 	const body = await request.json();
-	const { displayName, bankProfileId, ibanLast4, currency = 'EUR' } = body;
+	const { displayName, bankProfileId, ibanLast4, currency = PRIMARY_CURRENCY } = body;
 
 	if (!displayName?.trim()) throw error(400, 'displayName is required');
 	if (!bankProfileId) throw error(400, 'bankProfileId is required');

--- a/src/routes/api/accounts/[id]/resolve-fx/+server.ts
+++ b/src/routes/api/accounts/[id]/resolve-fx/+server.ts
@@ -4,6 +4,7 @@ import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts, currencyConversions, transactions } from '$lib/server/db/schema.js';
 import { propagateRateToAccount } from '$lib/server/currency-converter.js';
+import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 // ─── POST /api/accounts/[id]/resolve-fx ───────────────────────────────────────
 // Manually assign an exchange rate to unresolved transactions on a non-EUR account.
@@ -18,7 +19,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	});
 	if (!account) throw error(404, 'Account not found');
 	if (account.ownerUserId !== locals.user.id) throw error(403, 'Forbidden');
-	if (account.currency === 'EUR') throw error(400, 'Account is already EUR-denominated');
+	if (account.currency === PRIMARY_CURRENCY) throw error(400, 'Account is already EUR-denominated');
 
 	const body = await request.json();
 	const exchangeRate = parseFloat(body.exchangeRate);
@@ -47,7 +48,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	const eurAccount = await db.query.bankAccounts.findFirst({
 		where: and(
 			eq(bankAccounts.workspaceId, account.workspaceId),
-			eq(bankAccounts.currency, 'EUR'),
+			eq(bankAccounts.currency, PRIMARY_CURRENCY),
 			isNull(bankAccounts.deletedAt)
 		),
 		columns: { id: true }


### PR DESCRIPTION
## Summary

- Adds a rolling balance area chart to `/dashboard` showing cumulative net balance over the last 3 months (actual) plus a dashed projected trend to year-end
- Introduces a W/M/Q granularity selector (URL-driven via `?g=` param) — switching granularity re-buckets the chart without a full page reload
- Extracts `PRIMARY_CURRENCY = 'EUR'` constant across the codebase, replacing all hardcoded `'EUR'` strings in preparation for workspace-scoped currency support
- Adds a clean empty state inside the chart card when no transactions have been uploaded yet

## Details

- **`src/lib/currencies.ts`** — new `PRIMARY_CURRENCY` constant
- **`src/lib/server/db/queries.ts`** — `queryRollingBalance` with `DATE_TRUNC` bucketing via `sql.raw()`, cumulative sum in JS
- **`src/lib/chart-utils.ts`** — `buildProjection`: linear extrapolation from last actual point to Dec 31; always anchors domain at year-end to prevent d3 nice-rounding whitespace
- **`src/lib/components/BalanceChart.svelte`** — layerchart `AreaChart` + `LinearGradient`, solid line for actual data, dashed line for projection, both sharing the same pink gradient fill
- **`src/lib/components/GranularitySelector.svelte`** — segmented W/M/Q toggle

Closes #37