### PR TITLE
feat: AI category matching + auto-tagging on upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ ORIGIN=""
 # For production use 32 characters and generated with high entropy
 # https://www.better-auth.com/docs/installation
 BETTER_AUTH_SECRET=""
+
+# AI tagging (optional — features gracefully skip if not set)
+ANTHROPIC_API_KEY=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,26 @@ src/routes/
 | 6     | CSV export streaming                                       | Pending      |
 | 7     | Settings, upload history, mobile polish, empty states      | Pending      |
 
+## Design Decisions
+
+### Constants and magic numbers
+
+All shared constants live in `src/lib/constants/` as separate files grouped by domain (e.g. `colors.ts`, `ai.ts`). This path is available to both server and client code, so a single file can be imported by server modules (`$lib/server/`) and Svelte components alike — no duplication needed.
+
+- Do **not** define magic numbers inline in a module and re-export them as if they were that module's API.
+- Do **not** duplicate constants in a sibling `constants.ts` inside a component folder — import from `$lib/constants/` instead.
+- Server-only constants (e.g. a model ID, a batch size) can still live in `$lib/constants/` — being importable from the client doesn't mean the client must use them.
+
+### AI availability check
+
+`isAiAvailable()` in `src/lib/server/ai/tagger.ts` checks only that `ANTHROPIC_API_KEY` is set. A more accurate name would be `isAiConfigured()`. It does **not** guarantee the key is valid, that the account has credits, or that Anthropic's API is reachable.
+
+The real runtime guard is the `try/catch` inside each function in `tagger.ts`: on any failure, AI functions return graceful fallbacks (empty array / exact-match fallback) so the upload flow never breaks.
+
+**Things to improve later:**
+- Rename `isAiAvailable` → `isAiConfigured` for accuracy, or introduce a lightweight `/api/ai/status` health-check endpoint that caches the result of a real test call.
+- The `aiAvailable` flag passed from `+layout.server.ts` to the frontend is a weak signal — consider gating UI elements on observed AI results rather than the presence of a key.
+
 ## Coding Rules
 
 1. `$props()` with inline interface — never `export let`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,8 @@ const { data: session } = authClient.useSession();
 | `src/hooks.server.ts`              | Sets `locals.user` + `locals.session` via `svelteKitHandler`      |
 | `src/app.d.ts`                     | TypeScript types for `App.Locals`                                 |
 | `src/routes/layout.css`            | Global CSS + Tailwind v4 `@theme` design tokens                   |
-| `compose.yaml`                     | Docker Compose for local Postgres                                 |
+| `compose.yaml`                     | Docker Compose for local dev Postgres                             |
+| `compose.test.yaml`                | Docker Compose for isolated test Postgres (empty DB)              |
 | `scripts/seed-owner.ts`            | Creates first owner account (run once after first migration)      |
 
 ## Better Auth Patterns
@@ -120,6 +121,52 @@ npm run db:migrate    # applies migration to DB
 
 ## Development Setup
 
+### Local database environments
+
+Two independent Postgres containers share the same image (`postgres:16-alpine`) but use separate volumes:
+
+| Environment | Compose file | Container | Host port | Volume | Purpose |
+|-------------|-------------|-----------|-----------|--------|---------|
+| **Dev** | `compose.yaml` | `clair_db` | 5432 | `clair_clair_pgdata` | Primary workspace with real data (close-to-prod) |
+| **Test** | `compose.test.yaml` | `clair_db_test` | 5433 | `clair_test_clair_test_pgdata` | Empty DB for testing new features / breaking changes |
+
+Both can run side by side. The dev server connects to whichever you specify via `DATABASE_URL`.
+
+#### Running against dev (default)
+
+```bash
+docker compose up -d        # start dev DB on :5432
+npm run dev                 # uses DATABASE_URL from .env (port 5432)
+```
+
+#### Running against test
+
+```bash
+docker compose -f compose.test.yaml up -d   # start test DB on :5433
+DATABASE_URL="postgres://root:mysecretpassword@localhost:5433/local" npm run dev
+```
+
+#### First-time test DB setup
+
+```bash
+docker compose -f compose.test.yaml up -d
+
+# Apply migrations (drizzle-kit migrate doesn't support env override — apply SQL directly)
+for f in drizzle/migrations/0*.sql; do
+  sed 's/--> statement-breakpoint//g' "$f" | docker exec -i clair_db_test psql -U root -d local
+done
+
+# Seed a test user
+DATABASE_URL="postgres://root:mysecretpassword@localhost:5433/local" \
+  npx tsx scripts/seed-owner.ts --email=test@test.com --name="Test" --password=test1234
+```
+
+#### Tear down (without affecting dev)
+
+```bash
+docker compose -f compose.test.yaml down -v   # destroy test DB + data only
+```
+
 ### First time (fresh clone)
 
 ```bash
@@ -144,7 +191,7 @@ npm run db:studio        # open Drizzle Studio (DB GUI at localhost:4983)
 npm run auth:schema      # after editing auth.ts
 npm run db:generate      # after editing schema.ts
 npm run db:migrate       # apply pending migrations
-docker compose down -v   # destroy DB + data (full reset)
+docker compose down -v   # destroy dev DB + data (full reset)
 ```
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -55,6 +55,50 @@ docker compose up -d   # ensure DB is running
 npm run dev
 ```
 
+## Local database environments
+
+Two independent Postgres containers share the same image but use separate volumes so they can run side by side:
+
+| Environment | Compose file | Container | Host port | Purpose |
+|-------------|-------------|-----------|-----------|---------|
+| **Dev** | `compose.yaml` | `clair_db` | 5432 | Primary workspace with real data (close-to-prod) |
+| **Test** | `compose.test.yaml` | `clair_db_test` | 5433 | Empty DB for testing new features / breaking changes |
+
+### Running against dev (default)
+
+```bash
+docker compose up -d
+npm run dev                 # uses DATABASE_URL from .env (port 5432)
+```
+
+### Running against test
+
+```bash
+docker compose -f compose.test.yaml up -d
+DATABASE_URL="postgres://root:mysecretpassword@localhost:5433/local" npm run dev
+```
+
+### First-time test DB setup
+
+```bash
+docker compose -f compose.test.yaml up -d
+
+# Apply migrations
+for f in drizzle/migrations/0*.sql; do
+  sed 's/--> statement-breakpoint//g' "$f" | docker exec -i clair_db_test psql -U root -d local
+done
+
+# Seed a test user
+DATABASE_URL="postgres://root:mysecretpassword@localhost:5433/local" \
+  npx tsx scripts/seed-owner.ts --email=test@test.com --name="Test" --password=test1234
+```
+
+### Tear down test (without affecting dev)
+
+```bash
+docker compose -f compose.test.yaml down -v
+```
+
 ## Useful commands
 
 | Command                  | Description                                           |
@@ -66,7 +110,7 @@ npm run dev
 | `npm run db:generate`    | Generate a new Drizzle migration after schema changes |
 | `npm run db:migrate`     | Apply pending migrations to the database              |
 | `npm run db:studio`      | Open Drizzle Studio (DB GUI) at `localhost:4983`      |
-| `docker compose down -v` | Destroy the local DB and all data (full reset)        |
+| `docker compose down -v` | Destroy the dev DB and all data (full reset)          |
 
 ## Environment variables
 

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -1,0 +1,16 @@
+name: clair_test
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: clair_db_test
+    restart: unless-stopped
+    ports:
+      - 5433:5432
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: mysecretpassword
+      POSTGRES_DB: local
+    volumes:
+      - clair_test_pgdata:/var/lib/postgresql/data
+volumes:
+  clair_test_pgdata:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "clair",
 			"version": "0.0.1",
 			"dependencies": {
+				"@anthropic-ai/sdk": "^0.105.0",
 				"@types/papaparse": "^5.5.2",
 				"date-fns": "^4.1.0",
 				"papaparse": "^5.5.3",
@@ -54,6 +55,27 @@
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.57.0",
 				"vite": "^7.3.1"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.105.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.105.0.tgz",
+			"integrity": "sha512-sDyu+aM9cE6uZE+HgRjjHRb+qqb87GHZOx+8bE0YlWetdL1YcVLxn8h9ltxGOflyChTe6PMEo50kMQV4cw0hfg==",
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -559,6 +581,15 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
@@ -2713,6 +2744,12 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"license": "MIT"
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -5271,6 +5308,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"license": "Unlicense"
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5713,6 +5756,19 @@
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -7537,6 +7593,16 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
 		"node_modules/string_decoder": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7931,6 +7997,12 @@
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
 			"license": "MIT"
 		},
 		"node_modules/ts-api-utils": {
@@ -9358,7 +9430,7 @@
 			"version": "4.3.6",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"vite": "^7.3.1"
 	},
 	"dependencies": {
+		"@anthropic-ai/sdk": "^0.105.0",
 		"@types/papaparse": "^5.5.2",
 		"date-fns": "^4.1.0",
 		"papaparse": "^5.5.3",

--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { Component, Snippet } from 'svelte';
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		icon: Component<{ size: number }>;
+		title: string;
+		description?: string;
+		compact?: boolean;
+		class?: string;
+		children?: Snippet;
+	}
+	let { icon: Icon, title, description, compact = false, class: className, children }: Props = $props();
+</script>
+
+<div
+	class={cn(
+		'flex flex-col items-center justify-center px-4 text-center',
+		compact ? 'py-12' : 'py-24',
+		className
+	)}
+>
+	<div
+		class={cn(
+			'mb-4 flex items-center justify-center rounded-full bg-surface-sunken text-text-tertiary',
+			compact ? 'h-12 w-12' : 'h-14 w-14'
+		)}
+	>
+		<Icon size={compact ? 22 : 24} />
+	</div>
+	<p class="mb-1 text-sm font-medium text-text-primary">{title}</p>
+	{#if description}
+		<p class={cn('text-sm text-text-secondary', children ? 'mb-6' : '')}>{description}</p>
+	{/if}
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -12,7 +12,9 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
 	import Amount from '$lib/components/Amount.svelte';
+	import CategoryMappingSheet from '$lib/components/upload/CategoryMappingSheet.svelte';
 	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
+	import type { CategoryRow } from '$lib/types';
 
 	interface Props {
 		open: boolean;
@@ -32,7 +34,7 @@
 		isFirstUpload
 	}: Props = $props();
 
-	type Step = 'upload' | 'preview' | 'columns' | 'importing' | 'done';
+	type Step = 'upload' | 'preview' | 'columns' | 'categories' | 'importing' | 'done';
 	let step = $state<Step>('upload');
 	let loading = $state(false);
 	let err = $state<string | null>(null);
@@ -41,6 +43,12 @@
 	let balanceInput = $state('');
 
 	type ColumnMapping = { csvHeader: string; field: 'category' | 'city' | 'notes'; label: string };
+
+	type CategoryMappingEntry = {
+		csvCategory: string;
+		suggestedMatch: string | null;
+		confidence: number;
+	};
 
 	type PreviewData = {
 		filename: string;
@@ -52,6 +60,8 @@
 		columnMappings: ColumnMapping[];
 		unusedColumns: string[];
 		savedMappings: Array<{ field: string; csvHeader: string; enabled: boolean }>;
+		categoryMappings: CategoryMappingEntry[] | null;
+		workspaceCategories: CategoryRow[];
 	};
 
 	type DetectedConversion = {
@@ -96,6 +106,7 @@
 		detectedConversions: DetectedConversion[];
 		unresolvedTransfers: TransferMatch[];
 		newCategories: Array<{ name: string; color: string }>;
+		aiTagged: number;
 	};
 
 	let preview = $state<PreviewData | null>(null);
@@ -105,6 +116,7 @@
 		city: true,
 		notes: true
 	});
+	let categoryDecisions = $state<Record<string, string | null>>({});
 	// Per-match state: sourceId → 'linked' | 'skipped' | selectedCandidateId | null (pending)
 	let transferDecisions = $state<Record<string, string | null>>({});
 	let transferLinking = $state<Record<string, boolean>>({});
@@ -121,6 +133,7 @@
 		transferDecisions = {};
 		transferLinking = {};
 		columnConfirm = { category: true, city: true, notes: true };
+		categoryDecisions = {};
 	}
 
 	function handleOpenChange(v: boolean) {
@@ -180,6 +193,15 @@
 			if (data.openingBalance !== null) {
 				balanceInput = data.openingBalance.toFixed(2);
 			}
+			// Pre-populate category mapping decisions from AI suggestions
+			if (data.categoryMappings) {
+				categoryDecisions = Object.fromEntries(
+					data.categoryMappings.map((m: CategoryMappingEntry) => [
+						m.csvCategory,
+						m.suggestedMatch
+					])
+				);
+			}
 			// Pre-apply saved workspace mappings to confirm toggles
 			columnConfirm = { category: true, city: true, notes: true };
 			for (const saved of data.savedMappings ?? []) {
@@ -202,6 +224,13 @@
 		formData.append('file', file);
 		if (balanceInput.trim()) {
 			formData.append('openingBalance', balanceInput.replace(',', '.'));
+		}
+		// Send confirmed category mappings if any decisions were made
+		if (Object.keys(categoryDecisions).length > 0) {
+			const confirmedMappings = Object.entries(categoryDecisions).map(
+				([csvCategory, mappedTo]) => ({ csvCategory, mappedTo })
+			);
+			formData.append('categoryMappings', JSON.stringify(confirmedMappings));
 		}
 		// Send user-confirmed column overrides if there were any detected mappings
 		if (preview && preview.columnMappings.length > 0) {
@@ -256,11 +285,30 @@
 	const hasColumnsStep = $derived(
 		!!preview && (preview.columnMappings.length > 0 || preview.unusedColumns.length > 0)
 	);
-	const steps = $derived(
-		hasColumnsStep ? ['Upload', 'Preview', 'Columns', 'Done'] : ['Upload', 'Preview', 'Done']
+	// Show the categories step when there are non-exact category mappings to review
+	const hasCategoriesStep = $derived(
+		!!preview &&
+			!!preview.categoryMappings &&
+			preview.categoryMappings.length > 0 &&
+			preview.categoryMappings.some((m) => m.confidence < 1.0)
 	);
+	const steps = $derived(() => {
+		const s = ['Upload', 'Preview'];
+		if (hasColumnsStep) s.push('Columns');
+		if (hasCategoriesStep) s.push('Categories');
+		s.push('Done');
+		return s;
+	});
 	const stepIndex = $derived(
-		step === 'upload' ? 0 : step === 'preview' ? 1 : step === 'columns' ? 2 : steps.length - 1
+		step === 'upload'
+			? 0
+			: step === 'preview'
+				? 1
+				: step === 'columns'
+					? 2
+					: step === 'categories'
+						? (hasColumnsStep ? 3 : 2)
+						: steps().length - 1
 	);
 </script>
 
@@ -272,7 +320,7 @@
 		</Dialog.Header>
 
 		<div class="mb-4 flex shrink-0 gap-1.5">
-			{#each steps as _, i}
+			{#each steps() as _, i}
 				<div
 					class="h-1 flex-1 rounded-full transition-colors duration-300 {i <= stepIndex
 						? 'bg-primary-500'
@@ -481,6 +529,14 @@
 					</div>
 				{/if}
 
+				<!-- ── Step: Categories ── -->
+			{:else if step === 'categories' && preview?.categoryMappings}
+				<CategoryMappingSheet
+					mappings={preview.categoryMappings}
+					workspaceCategories={preview.workspaceCategories}
+					bind:decisions={categoryDecisions}
+				/>
+
 				<!-- ── Step: Importing ── -->
 			{:else if step === 'importing'}
 				<div class="flex flex-col items-center gap-3 py-12">
@@ -545,6 +601,16 @@
 										</span>
 									{/each}
 								</div>
+							</div>
+						{/if}
+
+						<!-- AI auto-tagging summary -->
+						{#if importResult.aiTagged > 0}
+							<div class="mb-3 w-full rounded-lg border border-primary-200 bg-primary-50 p-3 text-left">
+								<p class="text-xs font-medium text-primary-700">
+									AI auto-tagged {importResult.aiTagged}
+									{importResult.aiTagged === 1 ? 'transaction' : 'transactions'}
+								</p>
 							</div>
 						{/if}
 
@@ -767,6 +833,11 @@
 						Review columns
 						<ArrowRight size={14} />
 					</Button>
+				{:else if hasCategoriesStep}
+					<Button onclick={() => (step = 'categories')} disabled={loading}>
+						Review categories
+						<ArrowRight size={14} />
+					</Button>
 				{:else}
 					<Button onclick={submitImport} disabled={loading}>
 						Import {preview?.totalParsed ?? ''} transactions
@@ -775,6 +846,21 @@
 				{/if}
 			{:else if step === 'columns'}
 				<Button variant="outline" onclick={() => (step = 'preview')}>Back</Button>
+				{#if hasCategoriesStep}
+					<Button onclick={() => (step = 'categories')}>
+						Review categories
+						<ArrowRight size={14} />
+					</Button>
+				{:else}
+					<Button onclick={submitImport}>
+						Import {preview?.totalParsed ?? ''} transactions
+						<ArrowRight size={14} />
+					</Button>
+				{/if}
+			{:else if step === 'categories'}
+				<Button variant="outline" onclick={() => (step = hasColumnsStep ? 'columns' : 'preview')}>
+					Back
+				</Button>
 				<Button onclick={submitImport}>
 					Import {preview?.totalParsed ?? ''} transactions
 					<ArrowRight size={14} />

--- a/src/lib/components/upload/CategoryMappingSheet.svelte
+++ b/src/lib/components/upload/CategoryMappingSheet.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+	import * as Popover from '$lib/components/ui/popover';
+	import { cn } from '$lib/utils';
+	import { ArrowRight, Check, Plus, Sparkles } from '@lucide/svelte';
+	import type { CategoryRow } from '$lib/types';
+	import { CONFIDENCE_HIGH, CONFIDENCE_LOW } from '$lib/constants/ai';
+
+	interface MappingEntry {
+		csvCategory: string;
+		suggestedMatch: string | null;
+		confidence: number;
+	}
+
+	interface Props {
+		mappings: MappingEntry[];
+		workspaceCategories: CategoryRow[];
+		decisions: Record<string, string | null>;
+	}
+
+	let { mappings, workspaceCategories, decisions = $bindable() }: Props = $props();
+
+	// Track which rows have an open popover
+	let openPopovers = $state<Record<string, boolean>>({});
+
+	// Build grouped category list (parents + children)
+	const grouped = $derived(
+		workspaceCategories
+			.filter((c) => c.parentId === null)
+			.map((p) => ({
+				...p,
+				children: workspaceCategories.filter((c) => c.parentId === p.id)
+			}))
+	);
+
+	function selectCategory(csvCategory: string, categoryName: string | null) {
+		decisions[csvCategory] = categoryName;
+		openPopovers[csvCategory] = false;
+	}
+
+	function confidenceColor(confidence: number): string {
+		if (confidence >= CONFIDENCE_HIGH) return 'bg-success-500';
+		if (confidence >= CONFIDENCE_LOW) return 'bg-warning-500';
+		return 'bg-danger-400';
+	}
+
+	function confidenceLabel(confidence: number): string {
+		if (confidence >= CONFIDENCE_HIGH) return 'High confidence';
+		if (confidence >= CONFIDENCE_LOW) return 'Medium confidence';
+		return 'Low confidence';
+	}
+
+	// Find the category object for a given name
+	function findCategory(name: string | null) {
+		if (!name) return null;
+		return workspaceCategories.find((c) => c.name === name) ?? null;
+	}
+</script>
+
+<div>
+	<div class="mb-4">
+		<div class="mb-1 flex items-center gap-2">
+			<Sparkles size={14} class="text-primary-500" />
+			<p class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">
+				Category mapping
+			</p>
+		</div>
+		<p class="text-xs text-text-secondary">
+			We matched your CSV categories to existing ones. Review and adjust before importing.
+		</p>
+	</div>
+
+	<div class="space-y-1.5">
+		{#each mappings as mapping (mapping.csvCategory)}
+			{@const chosen = decisions[mapping.csvCategory]}
+			{@const chosenCat = findCategory(chosen)}
+
+			<div
+				class="flex items-center gap-2 rounded-lg border border-border p-2.5 transition-colors"
+			>
+				<!-- CSV category name -->
+				<div class="min-w-0 flex-1">
+					<p class="truncate text-xs font-medium text-text-primary">{mapping.csvCategory}</p>
+					{#if mapping.suggestedMatch && mapping.confidence > 0}
+						<div class="mt-0.5 flex items-center gap-1.5">
+							<span
+								class="h-1.5 w-1.5 shrink-0 rounded-full {confidenceColor(mapping.confidence)}"
+								title={confidenceLabel(mapping.confidence)}
+							></span>
+							<span class="text-[10px] text-text-tertiary">
+								{Math.round(mapping.confidence * 100)}% match
+							</span>
+						</div>
+					{/if}
+				</div>
+
+				<!-- Arrow -->
+				<ArrowRight size={12} class="shrink-0 text-text-tertiary" />
+
+				<!-- Category picker -->
+				<div class="flex-1">
+					<Popover.Root bind:open={openPopovers[mapping.csvCategory]}>
+						<Popover.Trigger
+							class={cn(
+								'flex w-full cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-left text-xs outline-none transition-colors',
+								'border-border hover:border-border-strong focus-visible:ring-1 focus-visible:ring-primary-400'
+							)}
+						>
+							{#if chosenCat}
+								<span
+									class="h-2 w-2 shrink-0 rounded-full"
+									style="background-color: {chosenCat.color}"
+								></span>
+								<span class="truncate text-text-primary">{chosen}</span>
+							{:else if chosen}
+								<span class="truncate text-text-primary">{chosen}</span>
+							{:else}
+								<Plus size={12} class="shrink-0 text-text-tertiary" />
+								<span class="text-text-tertiary">Create new</span>
+							{/if}
+						</Popover.Trigger>
+
+						<Popover.Content
+							class="z-50 max-h-60 w-52 gap-1 overflow-y-auto rounded-lg border border-border bg-surface p-1 shadow-md"
+							align="start"
+							sideOffset={4}
+						>
+							<!-- "Create new" option — keeps the CSV value as-is -->
+							<button
+								onclick={() => selectCategory(mapping.csvCategory, null)}
+								class={cn(
+									'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs outline-none hover:bg-surface-sunken',
+									chosen === null ? 'font-medium text-text-primary' : 'text-text-secondary'
+								)}
+							>
+								<Plus size={12} class="shrink-0" />
+								Create new category
+							</button>
+
+							<div class="-mx-1 my-1 h-px bg-border"></div>
+
+							<!-- Category tree -->
+							{#each grouped as parent}
+								<button
+									onclick={() => selectCategory(mapping.csvCategory, parent.name)}
+									class={cn(
+										'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs outline-none hover:bg-surface-sunken',
+										chosen === parent.name
+											? 'font-medium text-text-primary'
+											: 'text-text-secondary'
+									)}
+								>
+									<span
+										class="h-1.5 w-1.5 shrink-0 rounded-full"
+										style="background-color: {parent.color}"
+									></span>
+									{parent.name}
+									{#if chosen === parent.name}
+										<Check size={12} class="ml-auto text-primary-500" />
+									{/if}
+								</button>
+								{#each parent.children as child}
+									<button
+										onclick={() => selectCategory(mapping.csvCategory, child.name)}
+										class={cn(
+											'flex w-full items-center gap-2 rounded-md py-1.5 pr-2.5 pl-6 text-left text-xs outline-none hover:bg-surface-sunken',
+											chosen === child.name
+												? 'font-medium text-text-primary'
+												: 'text-text-secondary'
+										)}
+									>
+										<span
+											class="h-1.5 w-1.5 shrink-0 rounded-full"
+											style="background-color: {child.color}"
+										></span>
+										{child.name}
+										{#if chosen === child.name}
+											<Check size={12} class="ml-auto text-primary-500" />
+										{/if}
+									</button>
+								{/each}
+							{/each}
+						</Popover.Content>
+					</Popover.Root>
+				</div>
+			</div>
+		{/each}
+	</div>
+</div>

--- a/src/lib/components/upload/CategoryMappingSheet.svelte
+++ b/src/lib/components/upload/CategoryMappingSheet.svelte
@@ -19,8 +19,8 @@
 
 	let { mappings, workspaceCategories, decisions = $bindable() }: Props = $props();
 
-	// Track which rows have an open popover
-	let openPopovers = $state<Record<string, boolean>>({});
+	// Only one popover can be open at a time
+	let openPopover = $state<string | null>(null);
 
 	// Build grouped category list (parents + children)
 	const grouped = $derived(
@@ -34,7 +34,7 @@
 
 	function selectCategory(csvCategory: string, categoryName: string | null) {
 		decisions[csvCategory] = categoryName;
-		openPopovers[csvCategory] = false;
+		openPopover = null;
 	}
 
 	function confidenceColor(confidence: number): string {
@@ -98,7 +98,10 @@
 
 				<!-- Category picker -->
 				<div class="flex-1">
-					<Popover.Root bind:open={openPopovers[mapping.csvCategory]}>
+					<Popover.Root
+						open={openPopover === mapping.csvCategory}
+						onOpenChange={(v) => (openPopover = v ? mapping.csvCategory : null)}
+					>
 						<Popover.Trigger
 							class={cn(
 								'flex w-full cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-left text-xs outline-none transition-colors',

--- a/src/lib/constants/ai.ts
+++ b/src/lib/constants/ai.ts
@@ -1,0 +1,13 @@
+// ─── Confidence thresholds ────────────────────────────────────────────────────
+// Used by both server-side tagging logic and client-side UI.
+// ≥ HIGH  → write category directly
+// ≥ LOW   → write but flag as low-confidence
+// < LOW   → skip (leave uncategorised)
+export const CONFIDENCE_HIGH = 0.85;
+export const CONFIDENCE_LOW = 0.6;
+
+// ─── Model ───────────────────────────────────────────────────────────────────
+export const AI_MODEL = 'claude-haiku-4-5-20251001';
+
+// ─── Batching ────────────────────────────────────────────────────────────────
+export const TAG_BATCH_SIZE = 50;

--- a/src/lib/constants/ai.ts
+++ b/src/lib/constants/ai.ts
@@ -10,4 +10,8 @@ export const CONFIDENCE_LOW = 0.6;
 export const AI_MODEL = 'claude-haiku-4-5-20251001';
 
 // ─── Batching ────────────────────────────────────────────────────────────────
+// TAG_BATCH_SIZE controls how many transactions per AI call.
+// TAG_MAX_TOKENS must be large enough for TAG_BATCH_SIZE outputs: UUIDs tokenize
+// at ~1 char/token, so 50 items × ~60 tokens each ≈ 3000 tokens needed.
 export const TAG_BATCH_SIZE = 50;
+export const TAG_MAX_TOKENS = 4096;

--- a/src/lib/constants/ai.ts
+++ b/src/lib/constants/ai.ts
@@ -11,7 +11,7 @@ export const AI_MODEL = 'claude-haiku-4-5-20251001';
 
 // ─── Batching ────────────────────────────────────────────────────────────────
 // TAG_BATCH_SIZE controls how many transactions per AI call.
-// TAG_MAX_TOKENS must be large enough for TAG_BATCH_SIZE outputs: UUIDs tokenize
-// at ~1 char/token, so 50 items × ~60 tokens each ≈ 3000 tokens needed.
+// TAG_MAX_TOKENS covers the output for a full batch: with numeric IDs (not UUIDs)
+// each item costs ~10 tokens, so 50 items ≈ 500 tokens — 2048 gives safe headroom.
 export const TAG_BATCH_SIZE = 50;
-export const TAG_MAX_TOKENS = 4096;
+export const TAG_MAX_TOKENS = 2048;

--- a/src/lib/server/ai/auto-tag.ts
+++ b/src/lib/server/ai/auto-tag.ts
@@ -1,0 +1,122 @@
+import { and, eq, isNull, isNotNull, desc } from 'drizzle-orm';
+import { db } from '$lib/server/db/index.js';
+import { bankAccounts, categories, transactions } from '$lib/server/db/schema.js';
+import { isAiAvailable, tagBatch, type TagResult } from './tagger.js';
+import { CONFIDENCE_LOW, TAG_BATCH_SIZE } from '$lib/constants/ai.js';
+
+/**
+ * Auto-tags uncategorised transactions from a specific CSV upload.
+ * Only processes transactions where both `category` and `categoryOverride` are null.
+ *
+ * Returns { tagged, skipped } counts. Gracefully returns zeros when AI is unavailable.
+ */
+export async function autoTagUpload(
+	csvUploadId: string,
+	workspaceId: string
+): Promise<{ tagged: number; skipped: number }> {
+	if (!isAiAvailable()) return { tagged: 0, skipped: 0 };
+
+	// Find uncategorised transactions from this upload
+	const uncategorised = await db
+		.select({
+			id: transactions.id,
+			description: transactions.description,
+			amount: transactions.amount,
+			currency: transactions.currency
+		})
+		.from(transactions)
+		.where(
+			and(
+				eq(transactions.csvUploadId, csvUploadId),
+				isNull(transactions.category),
+				isNull(transactions.categoryOverride)
+			)
+		);
+
+	if (uncategorised.length === 0) return { tagged: 0, skipped: 0 };
+
+	// Load workspace category names
+	const workspaceCategories = await db
+		.select({ name: categories.name })
+		.from(categories)
+		.where(eq(categories.workspaceId, workspaceId));
+
+	const categoryNames = workspaceCategories.map((c) => c.name);
+	if (categoryNames.length === 0) return { tagged: 0, skipped: uncategorised.length };
+
+	// Build few-shot examples from recent user corrections
+	const fewShot = await buildFewShotExamples(workspaceId);
+
+	let tagged = 0;
+	let skipped = 0;
+
+	// Process in batches
+	for (let i = 0; i < uncategorised.length; i += TAG_BATCH_SIZE) {
+		const batch = uncategorised.slice(i, i + TAG_BATCH_SIZE);
+		const items = batch.map((tx) => ({
+			id: tx.id,
+			description: tx.description,
+			amount: parseFloat(tx.amount),
+			currency: tx.currency
+		}));
+
+		const results = await tagBatch(items, categoryNames, fewShot);
+		const resultMap = new Map<string, TagResult>(results.map((r) => [r.id, r]));
+
+		for (const tx of batch) {
+			const result = resultMap.get(tx.id);
+			if (!result || result.confidence < CONFIDENCE_LOW) {
+				skipped++;
+				continue;
+			}
+
+			await db
+				.update(transactions)
+				.set({
+					category: result.category,
+					categoryConfidence: result.confidence.toFixed(3),
+					...(result.isTransfer && result.confidence >= CONFIDENCE_LOW
+						? { isTransfer: true }
+						: {})
+				})
+				.where(eq(transactions.id, tx.id));
+			tagged++;
+		}
+	}
+
+	return { tagged, skipped };
+}
+
+/**
+ * Builds a few-shot prompt string from recent user category corrections.
+ * Uses transactions where `categoryOverride` is set — these represent
+ * human corrections that improve future AI tagging accuracy.
+ */
+async function buildFewShotExamples(workspaceId: string): Promise<string> {
+	// Get recent corrections by joining through bank accounts to filter by workspace
+	const corrections = await db
+		.select({
+			description: transactions.description,
+			amount: transactions.amount,
+			categoryOverride: transactions.categoryOverride
+		})
+		.from(transactions)
+		.innerJoin(bankAccounts, eq(transactions.bankAccountId, bankAccounts.id))
+		.where(
+			and(
+				eq(bankAccounts.workspaceId, workspaceId),
+				isNotNull(transactions.categoryOverride)
+			)
+		)
+		.orderBy(desc(transactions.accountingDate))
+		.limit(20);
+
+	if (corrections.length === 0) return '';
+
+	return corrections
+		.map(
+			(c) =>
+				`"${c.description}" (${c.amount}) → ${c.categoryOverride}`
+		)
+		.join('\n');
+}

--- a/src/lib/server/ai/auto-tag.ts
+++ b/src/lib/server/ai/auto-tag.ts
@@ -16,6 +16,18 @@ export async function autoTagUpload(
 ): Promise<{ tagged: number; skipped: number }> {
 	if (!isAiAvailable()) return { tagged: 0, skipped: 0 };
 
+	try {
+		return await _autoTagUpload(csvUploadId, workspaceId);
+	} catch (err) {
+		console.error('[AI] autoTagUpload failed — import still succeeded:', err);
+		return { tagged: 0, skipped: 0 };
+	}
+}
+
+async function _autoTagUpload(
+	csvUploadId: string,
+	workspaceId: string
+): Promise<{ tagged: number; skipped: number }> {
 	// Find uncategorised transactions from this upload
 	const uncategorised = await db
 		.select({

--- a/src/lib/server/ai/tagger.ts
+++ b/src/lib/server/ai/tagger.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/private';
 import Anthropic from '@anthropic-ai/sdk';
-import { AI_MODEL } from '$lib/constants/ai.js';
+import { AI_MODEL, TAG_MAX_TOKENS } from '$lib/constants/ai.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -85,23 +85,41 @@ Consider:
 Workspace categories: ${JSON.stringify(workspaceCategories)}
 CSV categories to match: ${JSON.stringify(csvCategories)}
 
-Return ONLY a valid JSON array. No explanation, no markdown.
-Each item: {"csv":"<original csv value>","match":"<workspace category name or null>","confidence":0.00}
-
 Set match to null if no good match exists (confidence < 0.5).
-Confidence should reflect how certain you are: 1.0 for exact/trivial matches, 0.85+ for clear semantic matches, 0.6-0.84 for plausible but uncertain matches.`
+Confidence: 1.0 for exact/trivial matches, 0.85+ for clear semantic matches, 0.6-0.84 for plausible but uncertain.`
 				}
-			]
+			],
+			output_config: {
+				format: {
+					type: 'json_schema',
+					schema: {
+						type: 'object',
+						properties: {
+							mappings: {
+								type: 'array',
+								items: {
+									type: 'object',
+									properties: {
+										csv: { type: 'string' },
+										match: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+										confidence: { type: 'number' }
+									},
+									required: ['csv', 'match', 'confidence'],
+									additionalProperties: false
+								}
+							}
+						},
+						required: ['mappings'],
+						additionalProperties: false
+					}
+				}
+			}
 		});
 
 		logUsage('matchCategories', res.usage);
 
-		const text = res.content[0].type === 'text' ? res.content[0].text : '[]';
-		const parsed = JSON.parse(text) as Array<{
-			csv: string;
-			match: string | null;
-			confidence: number;
-		}>;
+		const raw = res.content[0].type === 'text' ? res.content[0].text : '{"mappings":[]}';
+		const parsed = (JSON.parse(raw) as { mappings: Array<{ csv: string; match: string | null; confidence: number }> }).mappings;
 
 		// Validate: only return matches that are in the workspace categories list
 		const validNames = new Set(workspaceCategories);
@@ -142,25 +160,49 @@ export async function tagBatch(
 	try {
 		const res = await client.messages.create({
 			model: AI_MODEL,
-			max_tokens: 1024,
+			max_tokens: TAG_MAX_TOKENS,
 			messages: [
 				{
 					role: 'user',
 					content: `You are a personal finance transaction classifier for a Spanish user.
-Return ONLY a valid JSON array. No explanation, no markdown.
 ${fewShot ? `\nKnown corrections:\n${fewShot}\n` : ''}
 Categories: ${categories.join(', ')}
 Classify these ${items.length} transactions:
-${JSON.stringify(items)}
-Each item: {"id":"...","category":"...","confidence":0.00,"isTransfer":false}`
+${JSON.stringify(items)}`
 				}
-			]
+			],
+			output_config: {
+				format: {
+					type: 'json_schema',
+					schema: {
+						type: 'object',
+						properties: {
+							classifications: {
+								type: 'array',
+								items: {
+									type: 'object',
+									properties: {
+										id: { type: 'string' },
+										category: { type: 'string' },
+										confidence: { type: 'number' },
+										isTransfer: { type: 'boolean' }
+									},
+									required: ['id', 'category', 'confidence', 'isTransfer'],
+									additionalProperties: false
+								}
+							}
+						},
+						required: ['classifications'],
+						additionalProperties: false
+					}
+				}
+			}
 		});
 
 		logUsage('tagBatch', res.usage);
 
-		const text = res.content[0].type === 'text' ? res.content[0].text : '[]';
-		const parsed = JSON.parse(text) as TagResult[];
+		const raw = res.content[0].type === 'text' ? res.content[0].text : '{"classifications":[]}';
+		const parsed = (JSON.parse(raw) as { classifications: TagResult[] }).classifications;
 
 		// Validate: only accept categories from the provided list
 		const validNames = new Set(categories);

--- a/src/lib/server/ai/tagger.ts
+++ b/src/lib/server/ai/tagger.ts
@@ -1,0 +1,180 @@
+import { env } from '$env/dynamic/private';
+import Anthropic from '@anthropic-ai/sdk';
+import { AI_MODEL } from '$lib/constants/ai.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface CategoryMapping {
+	csvCategory: string;
+	matchedCategory: string | null;
+	confidence: number;
+}
+
+export interface TagItem {
+	id: string;
+	description: string;
+	amount: number;
+	currency: string;
+}
+
+export interface TagResult {
+	id: string;
+	category: string;
+	confidence: number;
+	isTransfer: boolean;
+}
+
+// ─── Client ─────────────────────────────────────────────────────────────────
+
+let _client: Anthropic | null = null;
+
+function getClient(): Anthropic | null {
+	if (_client) return _client;
+	const key = env.ANTHROPIC_API_KEY;
+	if (!key) return null;
+	_client = new Anthropic({ apiKey: key });
+	return _client;
+}
+
+export function isAiAvailable(): boolean {
+	return !!env.ANTHROPIC_API_KEY;
+}
+
+// ─── Category Matching ──────────────────────────────────────────────────────
+
+/**
+ * Uses AI to fuzzy-match CSV category values against workspace categories.
+ * Handles case differences, translations (e.g. Spanish ↔ English),
+ * abbreviations, and semantic similarity.
+ *
+ * Falls back to case-insensitive exact matching when AI is unavailable.
+ */
+export async function matchCategories(
+	csvCategories: string[],
+	workspaceCategories: string[]
+): Promise<CategoryMapping[]> {
+	if (csvCategories.length === 0) return [];
+
+	// Fallback: case-insensitive exact matching
+	const client = getClient();
+	if (!client || workspaceCategories.length === 0) {
+		const lowerMap = new Map(workspaceCategories.map((c) => [c.toLowerCase(), c]));
+		return csvCategories.map((csv) => {
+			const match = lowerMap.get(csv.toLowerCase().trim()) ?? null;
+			return { csvCategory: csv, matchedCategory: match, confidence: match ? 1.0 : 0 };
+		});
+	}
+
+	try {
+		const res = await client.messages.create({
+			model: AI_MODEL,
+			max_tokens: 1024,
+			messages: [
+				{
+					role: 'user',
+					content: `You are a personal finance category matcher.
+
+I have a list of category names from a CSV bank export and a list of canonical categories from the user's workspace. Match each CSV category to the best workspace category.
+
+Consider:
+- Case differences ("GROCERIES" → "Groceries")
+- Translations between Spanish and English ("Alimentación" → "Groceries", "Restaurantes" → "Restaurants")
+- Abbreviations and partial matches ("restaurants & other" → "Restaurants")
+- Semantic similarity ("Comida fuera" → "Restaurants", "Transporte público" → "Transport")
+
+Workspace categories: ${JSON.stringify(workspaceCategories)}
+CSV categories to match: ${JSON.stringify(csvCategories)}
+
+Return ONLY a valid JSON array. No explanation, no markdown.
+Each item: {"csv":"<original csv value>","match":"<workspace category name or null>","confidence":0.00}
+
+Set match to null if no good match exists (confidence < 0.5).
+Confidence should reflect how certain you are: 1.0 for exact/trivial matches, 0.85+ for clear semantic matches, 0.6-0.84 for plausible but uncertain matches.`
+				}
+			]
+		});
+
+		logUsage('matchCategories', res.usage);
+
+		const text = res.content[0].type === 'text' ? res.content[0].text : '[]';
+		const parsed = JSON.parse(text) as Array<{
+			csv: string;
+			match: string | null;
+			confidence: number;
+		}>;
+
+		// Validate: only return matches that are in the workspace categories list
+		const validNames = new Set(workspaceCategories);
+		return parsed.map((r) => ({
+			csvCategory: r.csv,
+			matchedCategory: r.match && validNames.has(r.match) ? r.match : null,
+			confidence: r.match && validNames.has(r.match) ? r.confidence : 0
+		}));
+	} catch (err) {
+		console.error('[AI] matchCategories failed:', err);
+		// Fallback to case-insensitive exact matching
+		const lowerMap = new Map(workspaceCategories.map((c) => [c.toLowerCase(), c]));
+		return csvCategories.map((csv) => {
+			const match = lowerMap.get(csv.toLowerCase().trim()) ?? null;
+			return { csvCategory: csv, matchedCategory: match, confidence: match ? 1.0 : 0 };
+		});
+	}
+}
+
+// ─── Transaction Tagging ────────────────────────────────────────────────────
+
+/**
+ * Classifies a batch of uncategorised transactions using AI.
+ * Returns category assignments with confidence scores.
+ *
+ * Returns empty array when AI is unavailable.
+ */
+export async function tagBatch(
+	items: TagItem[],
+	categories: string[],
+	fewShot?: string
+): Promise<TagResult[]> {
+	if (items.length === 0) return [];
+
+	const client = getClient();
+	if (!client) return [];
+
+	try {
+		const res = await client.messages.create({
+			model: AI_MODEL,
+			max_tokens: 1024,
+			messages: [
+				{
+					role: 'user',
+					content: `You are a personal finance transaction classifier for a Spanish user.
+Return ONLY a valid JSON array. No explanation, no markdown.
+${fewShot ? `\nKnown corrections:\n${fewShot}\n` : ''}
+Categories: ${categories.join(', ')}
+Classify these ${items.length} transactions:
+${JSON.stringify(items)}
+Each item: {"id":"...","category":"...","confidence":0.00,"isTransfer":false}`
+				}
+			]
+		});
+
+		logUsage('tagBatch', res.usage);
+
+		const text = res.content[0].type === 'text' ? res.content[0].text : '[]';
+		const parsed = JSON.parse(text) as TagResult[];
+
+		// Validate: only accept categories from the provided list
+		const validNames = new Set(categories);
+		return parsed.filter(
+			(r) => r.id && validNames.has(r.category) && typeof r.confidence === 'number'
+		);
+	} catch (err) {
+		console.error('[AI] tagBatch failed:', err);
+		return [];
+	}
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function logUsage(fn: string, usage: Anthropic.Usage) {
+	console.info(`[AI] ${fn}: ${usage.input_tokens} in / ${usage.output_tokens} out tokens`);
+}

--- a/src/lib/server/ai/tagger.ts
+++ b/src/lib/server/ai/tagger.ts
@@ -157,6 +157,18 @@ export async function tagBatch(
 	const client = getClient();
 	if (!client) return [];
 
+	// Map UUIDs to compact numeric IDs before sending to the model.
+	// UUIDs tokenize at ~1 token/char (36 tokens each) vs 1-2 tokens for a number,
+	// saving ~1700 tokens per 50-item batch. The model only echoes IDs back, so
+	// there is no semantic value in sending the full UUID.
+	const indexToId = new Map<string, string>(items.map((item, i) => [String(i), item.id]));
+	const remappedItems = items.map((item, i) => ({
+		id: String(i),
+		description: item.description,
+		amount: item.amount,
+		currency: item.currency
+	}));
+
 	try {
 		const res = await client.messages.create({
 			model: AI_MODEL,
@@ -168,7 +180,7 @@ export async function tagBatch(
 ${fewShot ? `\nKnown corrections:\n${fewShot}\n` : ''}
 Categories: ${categories.join(', ')}
 Classify these ${items.length} transactions:
-${JSON.stringify(items)}`
+${JSON.stringify(remappedItems)}`
 				}
 			],
 			output_config: {
@@ -204,11 +216,17 @@ ${JSON.stringify(items)}`
 		const raw = res.content[0].type === 'text' ? res.content[0].text : '{"classifications":[]}';
 		const parsed = (JSON.parse(raw) as { classifications: TagResult[] }).classifications;
 
-		// Validate: only accept categories from the provided list
+		// Remap numeric IDs back to the original UUIDs before returning.
+		// Drop any result whose ID the model hallucinated (not in indexToId).
 		const validNames = new Set(categories);
-		return parsed.filter(
-			(r) => r.id && validNames.has(r.category) && typeof r.confidence === 'number'
-		);
+		return parsed
+			.filter(
+				(r) =>
+					indexToId.has(r.id) &&
+					validNames.has(r.category) &&
+					typeof r.confidence === 'number'
+			)
+			.map((r) => ({ ...r, id: indexToId.get(r.id)! }));
 	} catch (err) {
 		console.error('[AI] tagBatch failed:', err);
 		return [];

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,7 +1,8 @@
 import { redirect } from '@sveltejs/kit';
 import type { LayoutServerLoad } from './$types';
+import { isAiAvailable } from '$lib/server/ai/tagger.js';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	if (!locals.user) redirect(303, '/login');
-	return { user: locals.user };
+	return { user: locals.user, aiAvailable: isAiAvailable() };
 };

--- a/src/routes/(app)/accounts/+page.svelte
+++ b/src/routes/(app)/accounts/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto, invalidateAll } from '$app/navigation';
 	import { AlertTriangle, Plus, Landmark } from '@lucide/svelte';
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import ResolveFxDialog from '$lib/components/accounts/ResolveFxDialog.svelte';
 	import AddAccountSheet from '$lib/components/accounts/AddAccountSheet.svelte';
 	import BankCard from '$lib/components/accounts/BankCard.svelte';
@@ -77,19 +78,16 @@
 
 	{#if data.accounts.length === 0}
 		<!-- Empty state -->
-		<div class="flex flex-col items-center justify-center px-4 py-24 text-center">
-			<div
-				class="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-surface-sunken text-text-tertiary"
-			>
-				<Landmark size={24} />
-			</div>
-			<p class="mb-1 text-sm font-medium text-text-primary">No bank accounts yet</p>
-			<p class="mb-6 text-sm text-text-secondary">Add your first account to get started.</p>
+		<EmptyState
+			icon={Landmark}
+			title="No bank accounts yet"
+			description="Add your first account to get started."
+		>
 			<Button size="sm" onclick={() => (addOpen = true)}>
 				<Plus size={15} />
 				Add bank account
 			</Button>
-		</div>
+		</EmptyState>
 	{:else}
 		<!-- Account cards grid -->
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 md:gap-4 lg:grid-cols-3">

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -12,12 +12,14 @@
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { TrendingUp, TrendingDown, Plus, Clock, MoreHorizontal, Landmark, BarChart2 } from '@lucide/svelte';
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import type { PageData } from './$types';
 	import type { Granularity } from '$lib/server/db/queries.js';
 
 	let { data }: { data: PageData } = $props();
 
 	const totalBalance = $derived(data.accounts.reduce((sum, a) => sum + a.currentBalance, 0));
+	const totalTxCount = $derived(data.accounts.reduce((sum, a) => sum + a.txCount, 0));
 
 	const formattedTotal = $derived(
 		new Intl.NumberFormat('es-ES', {
@@ -82,6 +84,11 @@
 				{/if}
 			{/if}
 		</div>
+		{#if data.accounts.length > 0 && totalTxCount === 0}
+			<p class="mt-3 text-sm text-text-secondary">
+				Upload a CSV to see your spending summary.
+			</p>
+		{/if}
 	</div>
 
 	<!-- Rolling balance chart -->
@@ -104,19 +111,12 @@
 						granularity={data.granularity}
 					/>
 				{:else}
-					<div class="flex h-56 flex-col items-center justify-center gap-3 text-center md:h-64">
-						<div
-							class="flex h-12 w-12 items-center justify-center rounded-full bg-surface-sunken text-text-tertiary"
-						>
-							<BarChart2 size={22} />
-						</div>
-						<div>
-							<p class="text-sm font-medium text-text-primary">No data yet</p>
-							<p class="mt-0.5 text-sm text-text-secondary">
-								Upload your first bank statement to see your balance history.
-							</p>
-						</div>
-					</div>
+					<EmptyState
+						icon={BarChart2}
+						title="No data yet"
+						description="Upload your first bank statement to see your balance history."
+						compact
+					/>
 				{/if}
 			</Card.Content>
 		</Card.Root>
@@ -137,19 +137,16 @@
 
 	{#if data.accounts.length === 0}
 		<!-- Empty state -->
-		<div class="flex flex-col items-center justify-center px-4 py-24 text-center">
-			<div
-				class="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-surface-sunken text-text-tertiary"
-			>
-				<Landmark size={24} />
-			</div>
-			<p class="mb-1 text-sm font-medium text-text-primary">No bank accounts yet</p>
-			<p class="mb-6 text-sm text-text-secondary">Add your first account to get started.</p>
+		<EmptyState
+			icon={Landmark}
+			title="No bank accounts yet"
+			description="Add your first account to get started."
+		>
 			<Button size="sm" href="/accounts">
 				<Plus size={15} />
 				Add bank account
 			</Button>
-		</div>
+		</EmptyState>
 	{:else}
 		<!-- Account cards grid -->
 		<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 md:gap-4 lg:grid-cols-3">

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -12,9 +12,11 @@
 		ChevronLeft,
 		ChevronRight,
 		Info,
-		CircleAlert
+		CircleAlert,
+		ReceiptText
 	} from '@lucide/svelte';
 	import Amount from '$lib/components/Amount.svelte';
+	import EmptyState from '$lib/components/EmptyState.svelte';
 	import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button, buttonVariants } from '$lib/components/ui/button';
@@ -249,15 +251,23 @@
 	<!-- ── Transactions table ──────────────────────────────────────────────────── -->
 	<div class="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
 		{#if data.rows.length === 0}
-			<div class="flex h-full flex-col items-center justify-center px-4 py-24 text-center">
-				<p class="mb-1 text-sm font-medium text-text-primary">No transactions found</p>
-				<p class="text-sm text-text-secondary">
-					{hasFilters ? 'Try adjusting your filters.' : 'Upload a CSV to get started.'}
-				</p>
+			<div class="flex h-full items-center justify-center">
 				{#if hasFilters}
-					<Button variant="link" onclick={clearFilters} class="mt-3 text-primary-500">
-						Clear all filters
-					</Button>
+					<EmptyState
+						icon={Search}
+						title="No transactions match your filters"
+						description="Try adjusting your filters."
+					>
+						<Button variant="link" onclick={clearFilters} class="text-primary-500">
+							Clear all filters
+						</Button>
+					</EmptyState>
+				{:else}
+					<EmptyState
+						icon={ReceiptText}
+						title="No transactions yet"
+						description="Upload a CSV from your bank account to get started."
+					/>
 				{/if}
 			</div>
 		{:else}

--- a/src/routes/api/accounts/[id]/import/+server.ts
+++ b/src/routes/api/accounts/[id]/import/+server.ts
@@ -1,5 +1,5 @@
 import { error, json } from '@sveltejs/kit';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, max } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import {
@@ -19,6 +19,7 @@ import { upsertOpeningBalance, refreshCurrentBalance } from '$lib/server/balance
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
 import { detectAndLinkTransfers } from '$lib/server/transfer-detector.js';
 import { detectAndCreateConversions } from '$lib/server/currency-converter.js';
+import { autoTagUpload } from '$lib/server/ai/auto-tag.js';
 import type { NormalizedTransaction } from '$lib/server/parsers/types.js';
 
 // ─── POST /api/accounts/[id]/import ───────────────────────────────────────────
@@ -43,6 +44,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	const columnMappingsRaw = formData.get('columnMappings') as string | null;
 	const columnOverrides: ColumnOverrides = columnMappingsRaw ? JSON.parse(columnMappingsRaw) : null;
 
+	// User-confirmed category mappings from the preview step
+	const categoryMappingsRaw = formData.get('categoryMappings') as string | null;
+	const confirmedCategoryMappings: Array<{ csvCategory: string; mappedTo: string | null }> | null =
+		categoryMappingsRaw ? JSON.parse(categoryMappingsRaw) : null;
+
 	let rows: Awaited<ReturnType<typeof uploadAndParse>>['result']['rows'];
 	let skippedCount: number;
 
@@ -52,6 +58,20 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		} = await uploadAndParse(file, account.bankProfileId, columnOverrides));
 	} catch (e) {
 		throw error(400, e instanceof Error ? e.message : 'Could not parse file');
+	}
+
+	// Apply confirmed category mappings to parsed rows
+	if (confirmedCategoryMappings && confirmedCategoryMappings.length > 0) {
+		const categoryMap = new Map(
+			confirmedCategoryMappings
+				.filter((m) => m.mappedTo !== null)
+				.map((m) => [m.csvCategory, m.mappedTo!])
+		);
+		for (const row of rows) {
+			if (row.category && categoryMap.has(row.category)) {
+				row.category = categoryMap.get(row.category)!;
+			}
+		}
 	}
 
 	// Create the upload record first (transactions reference it)
@@ -169,6 +189,9 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		detectAndCreateConversions(insertedIds, account.workspaceId, account.currency)
 	]);
 
+	// AI auto-tag uncategorised transactions (gracefully skips if no API key)
+	const aiTagResult = await autoTagUpload(upload.id, account.workspaceId);
+
 	return json({
 		imported: importedCount,
 		flagged: flaggedCount,
@@ -176,7 +199,8 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		duplicates: duplicateCount,
 		unresolvedTransfers,
 		detectedConversions,
-		newCategories
+		newCategories,
+		aiTagged: aiTagResult.tagged
 	});
 };
 
@@ -212,14 +236,21 @@ async function upsertNewCategories(
 	const toCreate = csvCategories.filter((name) => !existingNames.has(name.toLowerCase()));
 	if (toCreate.length === 0) return [];
 
+	// Compute next sortOrder for top-level categories in this workspace
+	const [{ maxOrder }] = await db
+		.select({ maxOrder: max(categories.sortOrder) })
+		.from(categories)
+		.where(and(eq(categories.workspaceId, workspaceId), isNull(categories.parentId)));
+	const startOrder = maxOrder != null ? maxOrder + 1 : 0;
+
 	const inserted = await db
 		.insert(categories)
 		.values(
-			toCreate.map((name) => ({
+			toCreate.map((name, i) => ({
 				workspaceId,
 				name,
 				color: randomCategoryColor(),
-				sortOrder: 0
+				sortOrder: startOrder + i
 			}))
 		)
 		.returning({ name: categories.name, color: categories.color });

--- a/src/routes/api/accounts/[id]/preview/+server.ts
+++ b/src/routes/api/accounts/[id]/preview/+server.ts
@@ -2,8 +2,9 @@ import { error, json } from '@sveltejs/kit';
 import { and, eq, isNull } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
-import { bankAccounts, csvColumnMappings } from '$lib/server/db/schema.js';
+import { bankAccounts, categories, csvColumnMappings } from '$lib/server/db/schema.js';
 import { uploadAndParse, detectFileDirection } from '$lib/server/parsers/index.js';
+import { matchCategories } from '$lib/server/ai/tagger.js';
 
 // ─── POST /api/accounts/[id]/preview ──────────────────────────────────────────
 // Parse a CSV for the given bank account and return a preview — no DB writes.
@@ -59,6 +60,37 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		where: eq(csvColumnMappings.workspaceId, account.workspaceId)
 	});
 
+	// AI-powered category matching: if the CSV has category values, match against workspace categories
+	const csvCategoryValues = [
+		...new Set(rows.map((r) => r.category?.trim()).filter(Boolean) as string[])
+	];
+
+	let categoryMappings: Array<{
+		csvCategory: string;
+		suggestedMatch: string | null;
+		confidence: number;
+	}> | null = null;
+
+	const workspaceCategories = await db
+		.select({
+			id: categories.id,
+			name: categories.name,
+			color: categories.color,
+			parentId: categories.parentId
+		})
+		.from(categories)
+		.where(eq(categories.workspaceId, account.workspaceId));
+
+	if (csvCategoryValues.length > 0) {
+		const workspaceCategoryNames = workspaceCategories.map((c) => c.name);
+		const aiMappings = await matchCategories(csvCategoryValues, workspaceCategoryNames);
+		categoryMappings = aiMappings.map((m) => ({
+			csvCategory: m.csvCategory,
+			suggestedMatch: m.matchedCategory,
+			confidence: m.confidence
+		}));
+	}
+
 	return json({
 		filename: file.name,
 		profile: account.bankProfileId,
@@ -74,6 +106,8 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 			csvHeader: m.columnLabel,
 			enabled: m.enabled
 		})),
+		categoryMappings,
+		workspaceCategories,
 		// Adaptive detection metadata — null when the strict profile was used successfully
 		detection: result.detectionMeta
 			? {

--- a/src/routes/api/settings/categories/+server.ts
+++ b/src/routes/api/settings/categories/+server.ts
@@ -1,5 +1,5 @@
 import { error, json } from '@sveltejs/kit';
-import { and, asc, eq, isNull, sql } from 'drizzle-orm';
+import { and, asc, eq, isNull, max, sql } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { categories } from '$lib/server/db/schema.js';
@@ -37,7 +37,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user.workspaceId) throw error(403, 'No workspace');
 
 	const body = await request.json();
-	const { name, color = '#6b7280', parentId = null, sortOrder = 0 } = body;
+	const { name, color = '#6b7280', parentId = null, sortOrder = undefined } = body;
 
 	if (!name?.trim()) throw error(400, 'name is required');
 	if (name.trim().length > 50) throw error(400, 'name must be 50 characters or fewer');
@@ -64,9 +64,20 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	});
 	if (sibling) throw error(409, `A category named "${name.trim()}" already exists at this level`);
 
+	// Compute sortOrder: use provided value if explicitly set, otherwise append at end
+	const scopeFilter = and(
+		eq(categories.workspaceId, workspaceId),
+		parentId === null ? isNull(categories.parentId) : eq(categories.parentId, parentId)
+	);
+	const [{ maxOrder }] = await db
+		.select({ maxOrder: max(categories.sortOrder) })
+		.from(categories)
+		.where(scopeFilter);
+	const resolvedSortOrder = sortOrder ?? (maxOrder != null ? maxOrder + 1 : 0);
+
 	const [created] = await db
 		.insert(categories)
-		.values({ workspaceId, name: name.trim(), color, parentId, sortOrder })
+		.values({ workspaceId, name: name.trim(), color, parentId, sortOrder: resolvedSortOrder })
 		.returning();
 
 	return json(created, { status: 201 });


### PR DESCRIPTION
Closes #39, closes #11.

## What this does

### Issue #39 — CSV category reconciliation
CSV bank exports often contain category values that don't align with workspace categories — different capitalisation, Spanish vs English, abbreviations, or semantically equivalent labels. Previously these were stored verbatim, creating near-duplicates.

Now:
- The **preview endpoint** extracts unique category values from the CSV and calls Claude Haiku to fuzzy-match them against the workspace's existing categories (translations, case, semantic similarity).
- A new **CategoryMappingSheet** step appears in the upload dialog when mappings are not exact 1:1. Each row shows the raw CSV value, the AI suggestion with a confidence indicator (green ≥ 85 %, yellow ≥ 60 %, red < 60 %), and a dropdown to accept, override, or create a new category.
- The **import endpoint** applies the user-confirmed mapping before inserting rows. Only categories where the user chose "Create new" are upserted.
- **sortOrder bug fixed**: new categories were always assigned `sortOrder = 0`. Now `max(sortOrder) + 1` is computed per scope (workspace + parent level) before inserting.

### Issue #11 — Auto-tagging uncategorised transactions
Transactions that arrive with no category (common for most bank CSVs) are now auto-tagged post-import using Claude Haiku.

- `autoTagUpload()` queries newly inserted transactions where both `category` and `categoryOverride` are null, batches them in groups of 50, and classifies each via AI.
- Results with confidence ≥ 0.60 get `category` + `categoryConfidence` written; below that threshold they are left uncategorised for manual review.
- Recent user corrections (`categoryOverride`) are included as few-shot examples to improve accuracy over time.
- The upload done screen shows "AI auto-tagged N transactions" when at least one was tagged.

## Design choices

### Numeric IDs for AI calls
UUIDs tokenise at roughly 1 token per character (36 tokens per UUID) because of the hyphens and hex segments. Before sending a batch to the model, each item is assigned a compact numeric index (`"0"`, `"1"`, ...). After the response the numeric IDs are mapped back to the original UUIDs. This saves ~1 700 tokens per 50-item batch, allowing `max_tokens` to stay at 2 048 instead of 4 096. Any hallucinated index not present in the map is silently dropped.

### Structured JSON outputs (`output_config`)
Both AI calls use `output_config.format.type = "json_schema"` with explicit schemas. This eliminates the need for assistant pre-fill hacks or post-processing to strip markdown fences — the API guarantees the response matches the schema.

### Graceful degradation
`ANTHROPIC_API_KEY` is optional. When absent, category matching falls back to case-insensitive exact matching and auto-tagging is skipped entirely — the upload flow never breaks. The public `autoTagUpload()` also wraps its implementation in a top-level try/catch so any unexpected AI or DB error returns `{ tagged: 0, skipped: 0 }` instead of failing the import.

### AI constants centralised in `$lib/constants/ai.ts`
`CONFIDENCE_HIGH`, `CONFIDENCE_LOW`, `AI_MODEL`, `TAG_BATCH_SIZE`, and `TAG_MAX_TOKENS` live in a single file importable by both server modules and Svelte components — no duplication, no circular dependencies.