### PR TITLE
Transaction export (round-trip-safe CSV)

### DIFF
--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -54,6 +54,10 @@
 		filename: string;
 		totalParsed: number;
 		skippedCount: number;
+		newCount: number;
+		duplicateCount: number;
+		updateCount: number;
+		reviewCount: number;
 		preview: Array<{ date: string; description: string; amount: number; currency: string }>;
 		openingBalance: number | null;
 		closingBalance: number | null;
@@ -196,10 +200,7 @@
 			// Pre-populate category mapping decisions from AI suggestions
 			if (data.categoryMappings) {
 				categoryDecisions = Object.fromEntries(
-					data.categoryMappings.map((m: CategoryMappingEntry) => [
-						m.csvCategory,
-						m.suggestedMatch
-					])
+					data.categoryMappings.map((m: CategoryMappingEntry) => [m.csvCategory, m.suggestedMatch])
 				);
 			}
 			// Pre-apply saved workspace mappings to confirm toggles
@@ -307,9 +308,45 @@
 				: step === 'columns'
 					? 2
 					: step === 'categories'
-						? (hasColumnsStep ? 3 : 2)
+						? hasColumnsStep
+							? 3
+							: 2
 						: steps().length - 1
 	);
+
+	// ── Preview headline / labels driven by the dedup projection ────────────────
+	const hasChanges = $derived(
+		!!preview && (preview.newCount > 0 || preview.updateCount > 0 || preview.reviewCount > 0)
+	);
+
+	const previewHeadline = $derived(
+		!preview || preview.newCount > 0
+			? 'Ready to import'
+			: preview.updateCount > 0 || preview.reviewCount > 0
+				? 'Ready to update'
+				: 'Nothing new to import'
+	);
+
+	const importActionLabel = $derived.by(() => {
+		if (!preview) return 'Import';
+		if (preview.newCount > 0)
+			return `Import ${preview.newCount} ${preview.newCount === 1 ? 'transaction' : 'transactions'}`;
+		if (preview.updateCount > 0 || preview.reviewCount > 0) return 'Apply updates';
+		return 'Import anyway';
+	});
+
+	// Secondary detail line: updates / review / unreadable rows (shown only when non-zero)
+	const previewDetail = $derived.by(() => {
+		if (!preview) return '';
+		const parts: string[] = [];
+		if (preview.updateCount > 0) parts.push(`${preview.updateCount} updated`);
+		if (preview.reviewCount > 0) parts.push(`${preview.reviewCount} need review`);
+		if (preview.skippedCount > 0)
+			parts.push(
+				`${preview.skippedCount} unreadable ${preview.skippedCount === 1 ? 'row' : 'rows'}`
+			);
+		return parts.join(' · ');
+	});
 </script>
 
 <Dialog.Root bind:open onOpenChange={handleOpenChange}>
@@ -370,32 +407,37 @@
 				<!-- Status banner -->
 				<div class="mb-5 flex items-center gap-3">
 					<div
-						class="bg-success-100 flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+						class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full {hasChanges
+							? 'bg-success-100'
+							: 'bg-surface-sunken'}"
 					>
-						<CheckCircle2 size={18} class="text-success-600" />
+						<CheckCircle2
+							size={18}
+							class={hasChanges ? 'text-success-600' : 'text-text-tertiary'}
+						/>
 					</div>
 					<div class="min-w-0">
-						<p class="text-sm font-semibold text-text-primary">Ready to import</p>
+						<p class="text-sm font-semibold text-text-primary">{previewHeadline}</p>
 						<p class="truncate text-xs text-text-secondary">
 							We've processed '{preview.filename}'
 						</p>
 					</div>
 				</div>
 
-				<!-- Stats grid -->
-				<div class="mb-5 grid grid-cols-3 gap-3">
+				<!-- Stats grid — projected dedup outcome (matches the import result) -->
+				<div class="mb-2 grid grid-cols-3 gap-3">
 					<div class="rounded-lg border border-border p-3">
 						<p class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">New</p>
 						<p class="mt-1 font-mono text-2xl font-bold text-text-primary tabular-nums">
-							{preview.totalParsed}
+							{preview.newCount}
 						</p>
 					</div>
 					<div class="rounded-lg border border-border p-3">
 						<p class="text-[10px] font-semibold tracking-wider text-text-tertiary uppercase">
-							Skipped
+							Duplicates
 						</p>
 						<p class="mt-1 font-mono text-2xl font-bold text-text-primary tabular-nums">
-							{preview.skippedCount}
+							{preview.duplicateCount}
 						</p>
 					</div>
 					<div class="rounded-lg border border-border-strong bg-surface-sunken p-3">
@@ -405,6 +447,9 @@
 						<p class="mt-1 truncate text-sm font-semibold text-text-primary">{accountName}</p>
 					</div>
 				</div>
+
+				<!-- Secondary detail: updates / review / unreadable rows -->
+				<p class="mb-5 h-4 text-xs text-text-tertiary">{previewDetail}</p>
 
 				<!-- Transaction preview table -->
 				<div class="mb-5 overflow-hidden rounded-lg border border-border">
@@ -606,7 +651,9 @@
 
 						<!-- AI auto-tagging summary -->
 						{#if importResult.aiTagged > 0}
-							<div class="mb-3 w-full rounded-lg border border-primary-200 bg-primary-50 p-3 text-left">
+							<div
+								class="mb-3 w-full rounded-lg border border-primary-200 bg-primary-50 p-3 text-left"
+							>
 								<p class="text-xs font-medium text-primary-700">
 									AI auto-tagged {importResult.aiTagged}
 									{importResult.aiTagged === 1 ? 'transaction' : 'transactions'}
@@ -840,7 +887,7 @@
 					</Button>
 				{:else}
 					<Button onclick={submitImport} disabled={loading}>
-						Import {preview?.totalParsed ?? ''} transactions
+						{importActionLabel}
 						<ArrowRight size={14} />
 					</Button>
 				{/if}
@@ -853,7 +900,7 @@
 					</Button>
 				{:else}
 					<Button onclick={submitImport}>
-						Import {preview?.totalParsed ?? ''} transactions
+						{importActionLabel}
 						<ArrowRight size={14} />
 					</Button>
 				{/if}

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, ilike, inArray, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, ilike, inArray, sql } from 'drizzle-orm';
 import { db } from './index.js';
 import { transactions, bankAccounts } from './schema.js';
 import { PRIMARY_CURRENCY } from '$lib/currencies.js';
@@ -125,6 +125,69 @@ export interface TxQueryResult {
 	counts: { all: number; expenses: number; transfers: number; review: number };
 	page: number;
 	limit: number;
+}
+
+// ---------------------------------------------------------------------------
+// Export query (no pagination) — round-trip-safe subset for CSV download
+// ---------------------------------------------------------------------------
+
+export interface ExportTxRow {
+	accountingDate: Date;
+	amount: number;
+	description: string;
+	currency: string;
+	accountName: string | null;
+	category: string | null; // AI-tagged category
+	categoryOverride: string | null; // user correction (takes precedence on export)
+	notes: string | null;
+	city: string | null;
+}
+
+/**
+ * Fetch every accessible transaction for CSV export.
+ *
+ * No pagination. Ordered accountingDate ASC then originalOrder ASC so a re-import
+ * lands rows in their original file sequence. Opening-balance rows are synthetic
+ * and excluded — they are not real transactions and would re-import oddly.
+ *
+ * @param accessibleIds account IDs the user may view (from getFullAccessAccountIds)
+ * @param accountIds optional subset to export; ignored entries outside accessibleIds
+ */
+export async function queryTransactionsForExport(
+	accessibleIds: string[],
+	accountIds?: string[]
+): Promise<ExportTxRow[]> {
+	if (accessibleIds.length === 0) return [];
+
+	// Intersect the requested subset with what the user is actually allowed to see.
+	const requested = accountIds?.length
+		? accountIds.filter((id) => accessibleIds.includes(id))
+		: accessibleIds;
+	if (requested.length === 0) return [];
+
+	const rows = await db
+		.select({
+			accountingDate: transactions.accountingDate,
+			amount: transactions.amount,
+			description: transactions.description,
+			currency: transactions.currency,
+			accountName: bankAccounts.displayName,
+			category: transactions.category,
+			categoryOverride: transactions.categoryOverride,
+			notes: transactions.notes,
+			city: transactions.city
+		})
+		.from(transactions)
+		.leftJoin(bankAccounts, eq(transactions.bankAccountId, bankAccounts.id))
+		.where(
+			and(inArray(transactions.bankAccountId, requested), eq(transactions.isOpeningBalance, false))
+		)
+		.orderBy(asc(transactions.accountingDate), asc(transactions.originalOrder));
+
+	return rows.map((r) => ({
+		...r,
+		amount: parseFloat(r.amount as string)
+	}));
 }
 
 export async function queryTransactions(params: TxQueryParams): Promise<TxQueryResult> {

--- a/src/lib/server/dedup.ts
+++ b/src/lib/server/dedup.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { db } from './db/index.js';
 import { transactions } from './db/schema.js';
-import type { NormalizedTransaction, DedupAction, DedupResult } from './parsers/types.js';
+import type { NormalizedTransaction, DedupResult } from './parsers/types.js';
 
 /**
  * Classify a normalised row before writing to the DB.
@@ -69,6 +69,44 @@ export async function classifyRow(
 	if (sameAmountDate.length > 1) return { action: 'review' };
 
 	return { action: 'insert' };
+}
+
+/**
+ * Dry-run classification summary used by the preview step so it can show the
+ * same New / Duplicates / Updates / Review breakdown the import will produce —
+ * without writing anything.
+ *
+ * The action → bucket mapping MUST stay in sync with the import loop in
+ * routes/api/accounts/[id]/import/+server.ts:
+ *   insert → new · review → review · update_status|update_desc → update · skip → duplicate
+ */
+export interface ClassificationSummary {
+	newCount: number;
+	duplicateCount: number;
+	updateCount: number;
+	reviewCount: number;
+}
+
+export async function summarizeClassification(
+	rows: NormalizedTransaction[],
+	bankAccountId: string
+): Promise<ClassificationSummary> {
+	const summary: ClassificationSummary = {
+		newCount: 0,
+		duplicateCount: 0,
+		updateCount: 0,
+		reviewCount: 0
+	};
+
+	for (const row of rows) {
+		const { action } = await classifyRow(row, bankAccountId);
+		if (action === 'insert') summary.newCount++;
+		else if (action === 'review') summary.reviewCount++;
+		else if (action === 'update_status' || action === 'update_desc') summary.updateCount++;
+		else summary.duplicateCount++; // 'skip'
+	}
+
+	return summary;
 }
 
 /**

--- a/src/lib/server/export/toCsv.ts
+++ b/src/lib/server/export/toCsv.ts
@@ -1,0 +1,58 @@
+import Papa from 'papaparse';
+import type { ExportTxRow } from '$lib/server/db/queries.js';
+
+/**
+ * Column headers, in order, for the exported CSV.
+ *
+ * Every header (except `Account`) is a synonym the adaptive parser recognises
+ * (see SEMANTIC_SYNONYMS in parsers/detector.ts), so a re-imported export is
+ * mapped back to the right fields. `Account` is intentionally not a parser field:
+ * it is human-readable context only and is ignored on re-import.
+ */
+export const EXPORT_HEADERS = [
+	'Date',
+	'Amount',
+	'Description',
+	'Currency',
+	'Account',
+	'Category',
+	'Notes',
+	'City'
+] as const;
+
+/**
+ * Format a Date as `yyyy-MM-dd` using its UTC parts.
+ *
+ * accountingDate is stored at UTC midnight; formatting via UTC (not local time)
+ * keeps the exported date identical to the stored value regardless of the server's
+ * timezone, which is what the dedup engine matches on re-import.
+ */
+function toIsoDateUTC(d: Date): string {
+	const yyyy = d.getUTCFullYear();
+	const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+	const dd = String(d.getUTCDate()).padStart(2, '0');
+	return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Serialise export rows to a round-trip-safe CSV string.
+ *
+ * - Date → `yyyy-MM-dd` (UTC), a format the parser recognises and the dedup keys on.
+ * - Amount → plain dot-decimal, no thousands separators (parseAmount-friendly).
+ * - Category → effective value: user override takes precedence over the AI tag,
+ *   matching what the /transactions page shows.
+ */
+export function toCsv(rows: ExportTxRow[]): string {
+	const records = rows.map((r) => ({
+		Date: toIsoDateUTC(r.accountingDate),
+		Amount: String(r.amount),
+		Description: r.description,
+		Currency: r.currency,
+		Account: r.accountName ?? '',
+		Category: r.categoryOverride ?? r.category ?? '',
+		Notes: r.notes ?? '',
+		City: r.city ?? ''
+	}));
+
+	return Papa.unparse({ fields: [...EXPORT_HEADERS], data: records }, { newline: '\r\n' });
+}

--- a/src/routes/(app)/export/+page.server.ts
+++ b/src/routes/(app)/export/+page.server.ts
@@ -1,0 +1,23 @@
+import { error } from '@sveltejs/kit';
+import { and, inArray, isNull } from 'drizzle-orm';
+import type { PageServerLoad } from './$types';
+import { db } from '$lib/server/db/index.js';
+import { bankAccounts } from '$lib/server/db/schema.js';
+import { getFullAccessAccountIds } from '$lib/server/db/access.js';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (!locals.user) error(401);
+
+	const accessibleIds = await getFullAccessAccountIds(locals.user.id);
+
+	const accounts =
+		accessibleIds.length > 0
+			? await db
+					.select({ id: bankAccounts.id, displayName: bankAccounts.displayName })
+					.from(bankAccounts)
+					.where(and(inArray(bankAccounts.id, accessibleIds), isNull(bankAccounts.deletedAt)))
+					.orderBy(bankAccounts.displayName)
+			: [];
+
+	return { accounts };
+};

--- a/src/routes/(app)/export/+page.svelte
+++ b/src/routes/(app)/export/+page.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { SvelteSet } from 'svelte/reactivity';
+	import { resolve } from '$app/paths';
+	import { Download, Landmark } from '@lucide/svelte';
+	import EmptyState from '$lib/components/EmptyState.svelte';
+	import { Button, buttonVariants } from '$lib/components/ui/button';
+	import { cn } from '$lib/utils';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	// All accounts selected by default.
+	let selected = $state<SvelteSet<string>>(new SvelteSet(data.accounts.map((a) => a.id)));
+
+	const allSelected = $derived(data.accounts.length > 0 && selected.size === data.accounts.length);
+	const noneSelected = $derived(selected.size === 0);
+
+	function toggle(id: string) {
+		if (selected.has(id)) selected.delete(id);
+		else selected.add(id);
+	}
+
+	function toggleAll() {
+		if (allSelected) selected.clear();
+		else for (const a of data.accounts) selected.add(a.id);
+	}
+
+	// Build the download URL. When every account is selected we omit the params
+	// entirely so the endpoint exports all accessible accounts with a clean URL.
+	const downloadHref = $derived.by(() => {
+		const base = resolve('/api/export');
+		if (allSelected) return base;
+		const query = [...selected].map((id) => `accountId=${encodeURIComponent(id)}`).join('&');
+		return `${base}?${query}`;
+	});
+</script>
+
+<div class="border-b border-border bg-surface px-4 pt-4 pb-3 md:px-8">
+	<h1 class="text-2xl font-semibold text-text-primary">Export</h1>
+	<p class="mt-1 text-sm text-text-secondary">
+		Download your transactions as a CSV. Re-importing the file is safe — duplicates are detected and
+		skipped.
+	</p>
+</div>
+
+<div class="px-4 py-6 md:px-8">
+	{#if data.accounts.length === 0}
+		<EmptyState
+			icon={Landmark}
+			title="No accounts to export"
+			description="Add a bank account and upload some transactions first."
+		/>
+	{:else}
+		<div class="mx-auto max-w-xl">
+			<div class="overflow-hidden rounded-lg border border-border bg-surface">
+				<div class="flex items-center justify-between border-b border-border px-4 py-3">
+					<span class="text-sm font-medium text-text-primary">Accounts</span>
+					<button
+						type="button"
+						onclick={toggleAll}
+						class="text-xs font-medium text-primary-600 hover:text-primary-700"
+					>
+						{allSelected ? 'Clear all' : 'Select all'}
+					</button>
+				</div>
+
+				<ul>
+					{#each data.accounts as account (account.id)}
+						<li class="border-b border-border last:border-b-0">
+							<label
+								class="flex cursor-pointer items-center gap-3 px-4 py-3 hover:bg-surface-sunken"
+							>
+								<input
+									type="checkbox"
+									checked={selected.has(account.id)}
+									onchange={() => toggle(account.id)}
+									class="h-4 w-4 shrink-0 accent-primary-500"
+								/>
+								<span class="text-sm text-text-primary">{account.displayName}</span>
+							</label>
+						</li>
+					{/each}
+				</ul>
+			</div>
+
+			<div class="mt-4 flex items-center justify-between">
+				<span class="text-xs text-text-tertiary">
+					{selected.size} of {data.accounts.length} selected
+				</span>
+
+				{#if noneSelected}
+					<Button disabled class="gap-2">
+						<Download class="size-4" />
+						Download CSV
+					</Button>
+				{:else}
+					<!-- downloadHref is built via resolve(); it carries a query string the rule can't verify statically -->
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a href={downloadHref} download class={cn(buttonVariants(), 'gap-2')}>
+						<Download class="size-4" />
+						Download CSV
+					</a>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/routes/api/accounts/[id]/preview/+server.ts
+++ b/src/routes/api/accounts/[id]/preview/+server.ts
@@ -4,6 +4,7 @@ import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db/index.js';
 import { bankAccounts, categories, csvColumnMappings } from '$lib/server/db/schema.js';
 import { uploadAndParse, detectFileDirection } from '$lib/server/parsers/index.js';
+import { summarizeClassification } from '$lib/server/dedup.js';
 import { matchCategories } from '$lib/server/ai/tagger.js';
 
 // ─── POST /api/accounts/[id]/preview ──────────────────────────────────────────
@@ -31,6 +32,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	}
 
 	const { rows, skippedCount } = result;
+
+	// Dry-run dedup so the preview shows the same New / Duplicates / Updates / Review
+	// breakdown the import will produce (dedup keys on date+amount+description, which
+	// are unaffected by category/city/notes column overrides — so this matches import).
+	const classification = await summarizeClassification(rows, account.id);
 
 	const preview = rows.slice(0, 5).map((r) => ({
 		date: r.accountingDate.toISOString().split('T')[0],
@@ -96,6 +102,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		profile: account.bankProfileId,
 		totalParsed: rows.length,
 		skippedCount,
+		// Dedup projection (matches the import outcome)
+		newCount: classification.newCount,
+		duplicateCount: classification.duplicateCount,
+		updateCount: classification.updateCount,
+		reviewCount: classification.reviewCount,
 		preview,
 		openingBalance,
 		closingBalance,

--- a/src/routes/api/export/+server.ts
+++ b/src/routes/api/export/+server.ts
@@ -1,0 +1,31 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { getFullAccessAccountIds } from '$lib/server/db/access.js';
+import { queryTransactionsForExport } from '$lib/server/db/queries.js';
+import { toCsv } from '$lib/server/export/toCsv.js';
+
+/**
+ * GET /api/export[?accountId=…&accountId=…]
+ *
+ * Streams a round-trip-safe CSV of the user's transactions. Without any
+ * `accountId` params it exports every accessible account; with them it exports
+ * only the requested subset (intersected with what the user may view).
+ */
+export const GET: RequestHandler = async ({ locals, url }) => {
+	if (!locals.user) error(401);
+
+	const accessibleIds = await getFullAccessAccountIds(locals.user.id);
+	const requested = url.searchParams.getAll('accountId');
+
+	const rows = await queryTransactionsForExport(accessibleIds, requested);
+	const csv = toCsv(rows);
+
+	const today = new Date().toISOString().slice(0, 10);
+
+	return new Response(csv, {
+		headers: {
+			'Content-Type': 'text/csv; charset=utf-8',
+			'Content-Disposition': `attachment; filename="clair-transactions-${today}.csv"`
+		}
+	});
+};

--- a/tests/export/run.ts
+++ b/tests/export/run.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+/**
+ * Export serialisation + round-trip tests.
+ *
+ * Verifies toCsv() produces a round-trip-safe CSV and that re-importing it
+ * through the adaptive parser maps every column back to the right field.
+ *
+ * Run: npx tsx tests/export/run.ts
+ */
+export {}; // mark as a module so top-level await type-checks
+
+const { toCsv, EXPORT_HEADERS } = await import('../../src/lib/server/export/toCsv.js');
+const { uploadAndParse } = await import('../../src/lib/server/parsers/index.js');
+
+let passed = 0;
+let failed = 0;
+
+function assert(label: string, condition: boolean, detail?: string) {
+	if (condition) {
+		console.log(`  ✓  ${label}`);
+		passed++;
+	} else {
+		console.log(`  ✗  ${label}${detail ? ` — ${detail}` : ''}`);
+		failed++;
+	}
+}
+
+console.log('\n══════════════════════════════════════════════════════════════════════════');
+console.log(' Export — serialisation & round-trip');
+console.log('══════════════════════════════════════════════════════════════════════════\n');
+
+// Sample rows mirroring the shape of queryTransactionsForExport() output.
+const rows = [
+	{
+		accountingDate: new Date(Date.UTC(2024, 5, 24)), // 2024-06-24
+		amount: -12.5,
+		description: 'Café La Cabra',
+		currency: 'EUR',
+		accountName: 'Revolut EUR',
+		category: 'Groceries', // AI tag
+		categoryOverride: 'Coffee', // user override → wins on export
+		notes: 'CPH Day 1',
+		city: 'Copenhagen'
+	},
+	{
+		accountingDate: new Date(Date.UTC(2024, 5, 25)), // 2024-06-25
+		amount: 1500,
+		description: 'Salary, June',
+		currency: 'EUR',
+		accountName: 'Bankinter',
+		category: null,
+		categoryOverride: null,
+		notes: null,
+		city: null
+	}
+];
+
+// ── Test 1: header line ────────────────────────────────────────────────────
+console.log('1. Serialisation');
+
+const csv = toCsv(rows);
+const lines = csv.trim().split('\r\n');
+
+assert(
+	'header line matches expected order',
+	lines[0] === EXPORT_HEADERS.join(','),
+	`got: ${lines[0]}`
+);
+assert(
+	'one data row per input row',
+	lines.length === rows.length + 1,
+	`got: ${lines.length} lines`
+);
+assert('date formatted yyyy-MM-dd', lines[1].startsWith('2024-06-24,'), `got: ${lines[1]}`);
+assert('amount is dot-decimal', lines[1].includes(',-12.5,'), `got: ${lines[1]}`);
+assert('effective category uses user override', lines[1].includes(',Coffee,'), `got: ${lines[1]}`);
+assert(
+	'null enrichment → empty cells (salary row ends with commas)',
+	/,,,$/.test(lines[2]),
+	`got: ${lines[2]}`
+);
+
+// ── Test 2: round-trip through the adaptive parser ─────────────────────────
+console.log('\n2. Round-trip: re-import the exported CSV');
+
+const file = new File([csv], 'clair-transactions-export.csv', { type: 'text/csv' });
+const { profileId, result } = await uploadAndParse(file, null);
+
+assert('detected as adaptive profile', profileId === 'adaptive', `got: ${profileId}`);
+assert('usedAdaptive = true', result.detectionMeta?.usedAdaptive === true);
+assert(
+	'all rows parsed, none skipped',
+	result.rows.length === rows.length && result.skippedCount === 0,
+	`parsed ${result.rows.length}, skipped ${result.skippedCount}`
+);
+
+const r0 = result.rows[0];
+assert(
+	'row 0 date round-trips',
+	r0?.accountingDate.toISOString().slice(0, 10) === '2024-06-24',
+	`got: ${r0?.accountingDate.toISOString()}`
+);
+assert('row 0 amount round-trips', r0?.amount === -12.5, `got: ${r0?.amount}`);
+assert(
+	'row 0 description round-trips',
+	r0?.description === 'Café La Cabra',
+	`got: ${r0?.description}`
+);
+assert('row 0 currency round-trips', r0?.currency === 'EUR', `got: ${r0?.currency}`);
+assert('row 0 category = override value', r0?.category === 'Coffee', `got: ${r0?.category}`);
+assert('row 0 notes round-trips', r0?.notes === 'CPH Day 1', `got: ${r0?.notes}`);
+assert('row 0 city round-trips', r0?.city === 'Copenhagen', `got: ${r0?.city}`);
+
+console.log(`\n  Parsed ${result.rows.length} rows, skipped ${result.skippedCount}`);
+console.log(
+	`  Column mappings: ${result.columnMappings.map((m) => `${m.csvHeader}→${m.field}`).join(', ')}`
+);
+
+// ── Summary ────────────────────────────────────────────────────────────────
+console.log('\n══════════════════════════════════════════════════════════════════════════');
+console.log(` Results: ${passed} passed, ${failed} failed`);
+console.log('══════════════════════════════════════════════════════════════════════════\n');
+
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
closes #12

## Why

The `/export` page rendered nothing. Users upload bank files → parse → dedupe → AI-categorise, but
there was no way to get the data back out in a clean tabular form. The database carries engine-only
noise (AI vs. user category, FX conversion internals, transfer links, internal UUIDs) that isn't
useful to an end user.

Per issue #12, the goal for v1 is deliberately simple: **pick one or more accounts, click download,
get a CSV of the transactions as shown on `/transactions`** — using the human-readable account name
instead of its id. Crucially, the export must be **round-trip safe**: re-importing the file must be
recognised by the existing parser/dedup engine so duplicates are skipped and nothing is
double-counted or broken.

## What changed

### 1. CSV export feature

| Area | File | Summary |
|------|------|---------|
| Query | `src/lib/server/db/queries.ts` | New `queryTransactionsForExport(accessibleIds, accountIds?)` — non-paginated, access-scoped, excludes synthetic opening-balance rows, ordered `accountingDate ASC, originalOrder ASC` (original file sequence). Returns the `ExportTxRow` subset only. |
| Serialiser | `src/lib/server/export/toCsv.ts` | Pure `toCsv(rows)` + `EXPORT_HEADERS`, using `papaparse`'s `Papa.unparse`. Dates as `yyyy-MM-dd` (UTC parts), amounts as plain dot-decimal, effective category = `categoryOverride ?? category`. |
| Endpoint | `src/routes/api/export/+server.ts` | `GET /api/export[?accountId=…]` — 401-guarded, scoped via `getFullAccessAccountIds`, intersects any requested subset, streams `text/csv` with a dated `Content-Disposition` filename. |
| Page | `src/routes/(app)/export/+page.server.ts` / `+page.svelte` | Multi-select account list (all selected by default), select/clear-all, empty state, **Download CSV** button. `/export` nav link already existed in `AppSidebar`. |
| Test | `tests/export/run.ts` | Serialisation + full round-trip through the real adaptive parser (16 assertions). Run: `npx tsx tests/export/run.ts`. |

**Exported columns:** `Date, Amount, Description, Currency, Account, Category, Notes, City`.

### 2. Import-preview UX fix (surfaced while testing the round-trip)

Re-importing an exported file exposed a pre-existing inconsistency: the upload **preview** step
showed "New 55 / Skipped 0", but the final step reported "0 imported / 55 duplicates". Root cause:
the preview never ran deduplication — its "New" was *rows parsed* and "Skipped" was *rows that failed
to parse*, neither of which is a duplicate count.

| Area | File | Summary |
|------|------|---------|
| Dedup | `src/lib/server/dedup.ts` | New `summarizeClassification(rows, accountId)` — dry-run that buckets rows exactly like the import loop (`insert→new`, `skip→duplicate`, `update_*→update`, `review→review`). |
| Endpoint | `src/routes/api/accounts/[id]/preview/+server.ts` | Runs the summary and returns `newCount / duplicateCount / updateCount / reviewCount`. |
| UI | `src/lib/components/accounts/UploadCsvDialog.svelte` | Stat grid now shows **New / Duplicates / Account** (real dedup projection). Banner headline and primary button are result-driven (e.g. "Nothing new to import" / "Import anyway" when re-importing an unchanged file). A secondary line surfaces updates / review / unreadable rows only when non-zero. Preview counts now match the final result. |

## How this satisfies issue #12

- **"Just a button that downloads all transactions, including the accountName."** — Delivered: the
  `/export` page downloads a CSV with `Account` = `bankAccounts.displayName`, mirroring the info on
  `/transactions`.
- **Round-trip safety (no double counting on re-import).** — A re-imported export won't match the
  Revolut/Bankinter header fingerprints, so it flows through the parser's **adaptive detection**. The
  export headers are chosen from the parser's synonym lists, so every column maps back
  (`Date→date`, `Amount→amount`, `Description→description`, `Currency→currency`, `Category→category`,
  `Notes→notes`, `City→city`; `Account` is intentionally ignored). Dates round-trip via UTC-midnight
  and amounts via dot-decimal, so the dedup engine matches on `(bankAccountId, accountingDate, amount)`
  and reports every row as a duplicate. Verified by `tests/export/run.ts`.
- **"A minimum set of columns required on import."** — Analysed and enforced:
  - **Required (dedup keys + parser recognition):** `Date`, `Amount`, `Description`, `Currency`.
  - **v1 extras (user-facing, parser-recognised):** `Account`, `Category`, `Notes`, `City`.

### Required vs. nice-to-have columns

**Compulsory for a smooth re-import** — without these the parser can't recognise the file or the
dedup engine can't re-identify a transaction:

| Column | Source | Role |
|--------|--------|------|
| `Date` | `accountingDate` (`yyyy-MM-dd`, UTC) | dedup key + header-row detection |
| `Amount` | `amount` (transaction currency, dot-decimal — **not** `amountEur`) | dedup key |
| `Description` | `description` | dedup key (md5 exact tier) + header-row detection |
| `Currency` | `currency` | correct amount interpretation, avoids FX ambiguity |

**Nice-to-have for a future v2** (intentionally out of scope here):

- **Internal transaction `id`** exported as a stable key + teaching the parser to read it as
  `externalId`. This is the real enabler for a *precise* round-trip that can safely apply edited
  category/notes/city back onto existing rows (dedup tier 1). Requires dedup `apply*` changes.
- Apply-on-reimport of category/notes/city edits (extend `applyDescUpdate` / add an
  `update_enrichment` action).
- Transfer links (`isTransfer`, `transferCounterpartId`), FX internals (`amountEur`, `exchangeRate`,
  `amountOriginal`, `currencyOriginal`, `conversionId`), `categoryConfidence`, `myPortion`, `tags`,
  `creditorName`/`debtorName`, `status`, `valueDate`, `originalOrder`.
- Column-selector UI and grouped summaries (by category / by account).

### Scope note

This ships the export only. The dedup engine still does **not** apply edited category/notes back onto
existing rows on re-import — today it skips duplicates, promotes pending→posted, and updates only the
description. Applying enrichment edits on re-upload is the v2 path described above.

## Verification

- `npm run check` — 0 errors.
- ESLint clean on all new files; `UploadCsvDialog.svelte` retains only pre-existing lint issues (none
  added).
- `npx tsx tests/export/run.ts` — 16/16 pass (serialisation + real-parser round-trip).
- Manual round-trip: export a Bankinter account, re-upload the CSV to the same account → preview and
  final step both report 0 new / all duplicates; account balance and transaction count unchanged.
