### PR TITLE
Enrichment round-trip + three-column category model

### DIFF
--- a/drizzle/migrations/0010_lonely_la_nuit.sql
+++ b/drizzle/migrations/0010_lonely_la_nuit.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "core"."transactions" ADD COLUMN "category_ai" text;
+--> statement-breakpoint
+-- Backfill: AI-written rows are exactly those with a confidence score. Move the
+-- AI guess out of the (now raw-only) `category` column into `category_ai` and
+-- clear `category` for those rows. File-provided categories (confidence NULL)
+-- stay in `category` as immutable raw. The effective value
+-- (override ?? category ?? category_ai) is unchanged for every existing row.
+UPDATE "core"."transactions"
+SET "category_ai" = "category", "category" = NULL
+WHERE "category_confidence" IS NOT NULL;

--- a/drizzle/migrations/meta/0010_snapshot.json
+++ b/drizzle/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1456 @@
+{
+  "id": "ae6faa83-53c0-4f43-9690-701f5d57aa6c",
+  "prevId": "912a4f2e-ab88-47bc-a86d-61454c2dd09a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban_last4": {
+          "name": "iban_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_data'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "account_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_accounts_workspace_id_workspaces_id_fk": {
+          "name": "bank_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.categories": {
+      "name": "categories",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_workspace_id_workspaces_id_fk": {
+          "name": "categories_workspace_id_workspaces_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_column_mappings": {
+      "name": "csv_column_mappings",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_key": {
+          "name": "column_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_label": {
+          "name": "column_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "csv_col_map_workspace_key_uidx": {
+          "name": "csv_col_map_workspace_key_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_column_mappings_workspace_id_workspaces_id_fk": {
+          "name": "csv_column_mappings_workspace_id_workspaces_id_fk",
+          "tableFrom": "csv_column_mappings",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_uploads": {
+      "name": "csv_uploads",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged_count": {
+          "name": "flagged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_updates": {
+          "name": "status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_from": {
+          "name": "date_range_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_to": {
+          "name": "date_range_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_uploads_bank_account_id_bank_accounts_id_fk": {
+          "name": "csv_uploads_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "csv_uploads",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.currency_conversions": {
+      "name": "currency_conversions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_account_id": {
+          "name": "from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_amount": {
+          "name": "from_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_amount": {
+          "name": "to_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "conversion_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "from_transaction_id": {
+          "name": "from_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_transaction_id": {
+          "name": "to_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "currency_conversions_to_account_idx": {
+          "name": "currency_conversions_to_account_idx",
+          "columns": [
+            {
+              "expression": "to_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "currency_conversions_workspace_id_workspaces_id_fk": {
+          "name": "currency_conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "currency_conversions_from_account_id_bank_accounts_id_fk": {
+          "name": "currency_conversions_from_account_id_bank_accounts_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "currency_conversions_to_account_id_bank_accounts_id_fk": {
+          "name": "currency_conversions_to_account_id_bank_accounts_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.invites": {
+      "name": "invites",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_workspace_id_workspaces_id_fk": {
+          "name": "invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transaction_overrides": {
+      "name": "transaction_overrides",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tx_override_user_idx": {
+          "name": "tx_override_user_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_overrides_transaction_id_transactions_id_fk": {
+          "name": "transaction_overrides_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_overrides",
+          "tableTo": "transactions",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transactions": {
+      "name": "transactions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csv_upload_id": {
+          "name": "csv_upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_date": {
+          "name": "accounting_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_original": {
+          "name": "amount_original",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency_original": {
+          "name": "currency_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditor_name": {
+          "name": "creditor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debtor_name": {
+          "name": "debtor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_ai": {
+          "name": "category_ai",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_confidence": {
+          "name": "category_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override": {
+          "name": "category_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override_by_id": {
+          "name": "category_override_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_transfer": {
+          "name": "is_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transfer_counterpart_id": {
+          "name": "transfer_counterpart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_by_id": {
+          "name": "transfer_linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_at": {
+          "name": "transfer_linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_fx_candidate": {
+          "name": "is_fx_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "conversion_id": {
+          "name": "conversion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "my_portion": {
+          "name": "my_portion",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_order": {
+          "name": "original_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_opening_balance": {
+          "name": "is_opening_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "sync_source": {
+          "name": "sync_source",
+          "type": "sync_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_dedup_idx": {
+          "name": "transactions_dedup_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_accounting_date_idx": {
+          "name": "transactions_accounting_date_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accounting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_idx": {
+          "name": "transactions_transfer_idx",
+          "columns": [
+            {
+              "expression": "transfer_counterpart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_conversion_idx": {
+          "name": "transactions_conversion_idx",
+          "columns": [
+            {
+              "expression": "conversion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_bank_account_id_bank_accounts_id_fk": {
+          "name": "transactions_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_csv_upload_id_csv_uploads_id_fk": {
+          "name": "transactions_csv_upload_id_csv_uploads_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "csv_uploads",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "csv_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.workspaces": {
+      "name": "workspaces",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_status": {
+      "name": "account_status",
+      "schema": "public",
+      "values": [
+        "no_data",
+        "active"
+      ]
+    },
+    "public.account_visibility": {
+      "name": "account_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "stats_only",
+        "full"
+      ]
+    },
+    "public.conversion_confidence": {
+      "name": "conversion_confidence",
+      "schema": "public",
+      "values": [
+        "auto",
+        "confirmed",
+        "manual"
+      ]
+    },
+    "public.sync_source": {
+      "name": "sync_source",
+      "schema": "public",
+      "values": [
+        "csv_upload",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "posted",
+        "review"
+      ]
+    }
+  },
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1775754069631,
       "tag": "0009_new_energizer",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785756972682,
+      "tag": "0010_lonely_la_nuit",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/CategorySelector.svelte
+++ b/src/lib/components/CategorySelector.svelte
@@ -6,17 +6,18 @@
 
 	interface Props {
 		txId: string;
-		category: string | null;
-		categoryOverride: string | null;
+		category: string | null; // raw bank-file value
+		categoryAI?: string | null; // AI guess
+		categoryOverride: string | null; // human decision
 		categories: CategoryRow[];
 	}
-	let { txId, category, categoryOverride, categories }: Props = $props();
+	let { txId, category, categoryAI = null, categoryOverride, categories }: Props = $props();
 
 	let open = $state(false);
 	let pending = $state(false);
 	let localOverride = $state(categoryOverride);
 
-	const effective = $derived(localOverride ?? category);
+	const effective = $derived(localOverride ?? category ?? categoryAI);
 
 	const effectiveCat = $derived(categories.find((c) => c.name === effective) ?? null);
 

--- a/src/lib/components/accounts/UploadCsvDialog.svelte
+++ b/src/lib/components/accounts/UploadCsvDialog.svelte
@@ -106,6 +106,7 @@
 		imported: number;
 		flagged: number;
 		statusUpdates: number;
+		enrichmentUpdates: number;
 		duplicates: number;
 		detectedConversions: DetectedConversion[];
 		unresolvedTransfers: TransferMatch[];
@@ -615,7 +616,7 @@
 								<p class="font-mono text-xl font-bold text-text-primary">
 									{importResult.statusUpdates}
 								</p>
-								<p class="text-xs text-text-secondary">Status updates</p>
+								<p class="text-xs text-text-secondary">Updated</p>
 							</div>
 						{/if}
 						{#if importResult.flagged > 0}

--- a/src/lib/server/ai/auto-tag.ts
+++ b/src/lib/server/ai/auto-tag.ts
@@ -6,7 +6,9 @@ import { CONFIDENCE_LOW, TAG_BATCH_SIZE } from '$lib/constants/ai.js';
 
 /**
  * Auto-tags uncategorised transactions from a specific CSV upload.
- * Only processes transactions where both `category` and `categoryOverride` are null.
+ * Only processes transactions where `categoryOverride`, `category` (raw bank value)
+ * and `categoryAI` are all null — so a row that already carries any category value
+ * (human, bank-file, or a previous AI guess) is never re-tagged.
  *
  * Returns { tagged, skipped } counts. Gracefully returns zeros when AI is unavailable.
  */
@@ -40,8 +42,9 @@ async function _autoTagUpload(
 		.where(
 			and(
 				eq(transactions.csvUploadId, csvUploadId),
+				isNull(transactions.categoryOverride),
 				isNull(transactions.category),
-				isNull(transactions.categoryOverride)
+				isNull(transactions.categoryAI)
 			)
 		);
 
@@ -89,7 +92,7 @@ async function _autoTagUpload(
 			await db
 				.update(transactions)
 				.set({
-					category: result.category,
+					categoryAI: result.category,
 					categoryConfidence: result.confidence.toFixed(3),
 					...(result.isTransfer && result.confidence >= CONFIDENCE_LOW
 						? { isTransfer: true }

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -112,8 +112,9 @@ export interface TxRow {
 	isTransfer: boolean;
 	isOpeningBalance: boolean;
 	notes: string | null;
-	category: string | null;
-	categoryOverride: string | null;
+	category: string | null; // raw bank-file value
+	categoryAI: string | null; // AI guess
+	categoryOverride: string | null; // human decision
 	bankAccountId: string;
 	accountName: string | null;
 	bankProfileId: string | null;
@@ -132,13 +133,15 @@ export interface TxQueryResult {
 // ---------------------------------------------------------------------------
 
 export interface ExportTxRow {
+	id: string; // internal transaction id — emitted as the optional Id column for exact round-trip
 	accountingDate: Date;
 	amount: number;
 	description: string;
 	currency: string;
 	accountName: string | null;
-	category: string | null; // AI-tagged category
-	categoryOverride: string | null; // user correction (takes precedence on export)
+	category: string | null; // raw bank-file value
+	categoryAI: string | null; // AI guess
+	categoryOverride: string | null; // human decision (takes precedence on export)
 	notes: string | null;
 	city: string | null;
 }
@@ -167,12 +170,14 @@ export async function queryTransactionsForExport(
 
 	const rows = await db
 		.select({
+			id: transactions.id,
 			accountingDate: transactions.accountingDate,
 			amount: transactions.amount,
 			description: transactions.description,
 			currency: transactions.currency,
 			accountName: bankAccounts.displayName,
 			category: transactions.category,
+			categoryAI: transactions.categoryAI,
 			categoryOverride: transactions.categoryOverride,
 			notes: transactions.notes,
 			city: transactions.city
@@ -245,6 +250,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 				isOpeningBalance: transactions.isOpeningBalance,
 				notes: transactions.notes,
 				category: transactions.category,
+				categoryAI: transactions.categoryAI,
 				categoryOverride: transactions.categoryOverride,
 				bankAccountId: transactions.bankAccountId,
 				accountName: bankAccounts.displayName,

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -142,8 +142,11 @@ export const transactions = coreSchema.table(
 		creditorName: text('creditor_name'),
 		debtorName: text('debtor_name'),
 
-		// AI tagging — never overwritten on re-upload
+		// Bank-file value exactly as imported (immutable raw); null when the file had no category
 		category: text('category'),
+		// AI guess — the only auto-generated category. Written by autoTagUpload; never touched on re-upload
+		categoryAI: text('category_ai'),
+		// Pairs with categoryAI — the AI's confidence in that guess
 		categoryConfidence: numeric('category_confidence', { precision: 4, scale: 3 }),
 
 		// User corrections — never overwritten on re-upload

--- a/src/lib/server/dedup.ts
+++ b/src/lib/server/dedup.ts
@@ -1,36 +1,70 @@
 import { eq } from 'drizzle-orm';
 import { db } from './db/index.js';
 import { transactions } from './db/schema.js';
-import type { NormalizedTransaction, DedupResult } from './parsers/types.js';
+import type { NormalizedTransaction, DedupResult, EnrichmentDelta } from './parsers/types.js';
+import { computeEnrichmentDelta, type EnrichableExisting } from './enrichment.js';
+
+/**
+ * The subset of an existing transaction the dedup engine needs to decide an action
+ * and compute an enrichment delta.
+ */
+interface ExistingRow extends EnrichableExisting {
+	id: string;
+	status: 'pending' | 'posted' | 'review';
+}
+
+const EXISTING_COLUMNS = {
+	id: true,
+	status: true,
+	category: true,
+	categoryAI: true,
+	categoryOverride: true,
+	notes: true,
+	city: true
+} as const;
 
 /**
  * Classify a normalised row before writing to the DB.
  *
  * Priority order:
+ *  0. internalId match — an id echoed back by a Clair export+re-import (`transactions.id`).
+ *     Exact and authoritative; makes edit attribution precise even for identical bank rows.
  *  1. externalId match (when the bank profile provides one)
  *  2. accountingDate + amount + description exact match
  *  3. accountingDate + amount only (description may have changed)
  *
- * PENDING → POSTED transitions trigger "update_status" instead of "skip",
- * preserving all user-enriched fields (category, notes, city, tags).
+ * On any match, an enrichment delta is computed from the row's (re-imported) Category /
+ * Notes / City cells vs the stored values. When the effective category, notes, or city
+ * changed, the delta is attached so the import loop can apply the user's edits:
+ *  - PENDING → POSTED transitions stay `update_status` (+ enrichment payload).
+ *  - An exact match with only enrichment changes becomes `update_enrichment`.
+ *  - A same-date+amount match with a changed description stays `update_desc` (+ enrichment).
+ *  - A match with no status change and no enrichment delta stays `skip` (a true duplicate).
  */
 export async function classifyRow(
 	row: NormalizedTransaction,
 	bankAccountId: string,
 	externalId?: string
 ): Promise<DedupResult> {
+	// Priority 0: internal id echoed back from a Clair export
+	if (row.internalId) {
+		const existing = await db.query.transactions.findFirst({
+			where: (t, { and, eq }) =>
+				and(eq(t.bankAccountId, bankAccountId), eq(t.id, row.internalId!)),
+			columns: EXISTING_COLUMNS
+		});
+		// Only trust the id when it resolves within this account; otherwise fall through.
+		if (existing) return resolveExactMatch(existing, row);
+	}
+
 	// Priority 1: externalId match
 	if (externalId) {
 		const existing = await db.query.transactions.findFirst({
 			where: (t, { and, eq }) =>
 				and(eq(t.bankAccountId, bankAccountId), eq(t.externalId, externalId)),
-			columns: { id: true, status: true }
+			columns: EXISTING_COLUMNS
 		});
-		if (existing) {
-			if (existing.status === 'pending' && row.status === 'posted')
-				return { action: 'update_status', existingId: existing.id };
-			return { action: 'skip' };
-		}
+		if (existing) return resolveExactMatch(existing, row);
 	}
 
 	// Priority 2: accountingDate + amount + description (exact)
@@ -42,13 +76,9 @@ export async function classifyRow(
 				s`${t.amount}::numeric = ${row.amount}`,
 				s`md5(${t.description}) = md5(${row.description})`
 			),
-		columns: { id: true, status: true }
+		columns: EXISTING_COLUMNS
 	});
-	if (sameExact) {
-		if (sameExact.status === 'pending' && row.status === 'posted')
-			return { action: 'update_status', existingId: sameExact.id };
-		return { action: 'skip' };
-	}
+	if (sameExact) return resolveExactMatch(sameExact, row);
 
 	// Priority 3: accountingDate + amount only (description may have changed)
 	const sameAmountDate = await db.query.transactions.findMany({
@@ -58,17 +88,32 @@ export async function classifyRow(
 				eq(t.accountingDate, row.accountingDate),
 				s`${t.amount}::numeric = ${row.amount}`
 			),
-		columns: { id: true, status: true }
+		columns: EXISTING_COLUMNS
 	});
 
 	if (sameAmountDate.length === 1) {
-		if (sameAmountDate[0].status === 'pending' && row.status === 'posted')
-			return { action: 'update_status', existingId: sameAmountDate[0].id };
-		return { action: 'update_desc', existingId: sameAmountDate[0].id };
+		const existing = sameAmountDate[0];
+		const enrichment = computeEnrichmentDelta(existing, row);
+		if (existing.status === 'pending' && row.status === 'posted')
+			return { action: 'update_status', existingId: existing.id, enrichment };
+		// Description changed (out of contract) — still apply enrichment on this branch.
+		return { action: 'update_desc', existingId: existing.id, enrichment };
 	}
 	if (sameAmountDate.length > 1) return { action: 'review' };
 
 	return { action: 'insert' };
+}
+
+/**
+ * Decide the action for a row matched exactly (tier 0/1/2) to a single existing row.
+ * Prefers a PENDING→POSTED status upgrade, then an enrichment update, else a plain skip.
+ */
+function resolveExactMatch(existing: ExistingRow, row: NormalizedTransaction): DedupResult {
+	const enrichment = computeEnrichmentDelta(existing, row);
+	if (existing.status === 'pending' && row.status === 'posted')
+		return { action: 'update_status', existingId: existing.id, enrichment };
+	if (enrichment) return { action: 'update_enrichment', existingId: existing.id, enrichment };
+	return { action: 'skip' };
 }
 
 /**
@@ -78,7 +123,8 @@ export async function classifyRow(
  *
  * The action → bucket mapping MUST stay in sync with the import loop in
  * routes/api/accounts/[id]/import/+server.ts:
- *   insert → new · review → review · update_status|update_desc → update · skip → duplicate
+ *   insert → new · review → review ·
+ *   update_status|update_desc|update_enrichment → update · skip → duplicate
  */
 export interface ClassificationSummary {
 	newCount: number;
@@ -102,7 +148,12 @@ export async function summarizeClassification(
 		const { action } = await classifyRow(row, bankAccountId);
 		if (action === 'insert') summary.newCount++;
 		else if (action === 'review') summary.reviewCount++;
-		else if (action === 'update_status' || action === 'update_desc') summary.updateCount++;
+		else if (
+			action === 'update_status' ||
+			action === 'update_desc' ||
+			action === 'update_enrichment'
+		)
+			summary.updateCount++;
 		else summary.duplicateCount++; // 'skip'
 	}
 
@@ -142,4 +193,28 @@ export async function applyDescUpdate(
 			updatedAt: new Date()
 		})
 		.where(eq(transactions.id, existingId));
+}
+
+/**
+ * Apply an enrichment delta (edited Category / Notes / City) onto an existing row.
+ *
+ * A changed category is written as `categoryOverride` (a human decision) — the raw
+ * `category` and AI `categoryAI` columns are left untouched, so provenance and the
+ * AI-skip guard stay intact and repeated round-trips are idempotent. `overrideById`
+ * records who imported the edit.
+ */
+export async function applyEnrichmentUpdate(
+	existingId: string,
+	delta: EnrichmentDelta,
+	overrideById: string
+): Promise<void> {
+	const set: Partial<typeof transactions.$inferInsert> = { updatedAt: new Date() };
+	if (delta.categoryOverride !== undefined) {
+		set.categoryOverride = delta.categoryOverride;
+		set.categoryOverrideById = overrideById;
+	}
+	if (delta.notes !== undefined) set.notes = delta.notes;
+	if (delta.city !== undefined) set.city = delta.city;
+
+	await db.update(transactions).set(set).where(eq(transactions.id, existingId));
 }

--- a/src/lib/server/enrichment.ts
+++ b/src/lib/server/enrichment.ts
@@ -1,0 +1,48 @@
+import type { NormalizedTransaction, EnrichmentDelta } from './parsers/types.js';
+
+/**
+ * The stored category/notes/city fields an incoming re-imported row is diffed against.
+ * Structurally a subset of a persisted transaction — kept db-free so this module (and the
+ * diff below) stays pure and unit-testable without a database connection.
+ */
+export interface EnrichableExisting {
+	category: string | null; // raw bank-file value
+	categoryAI: string | null; // AI guess
+	categoryOverride: string | null; // human decision
+	notes: string | null;
+	city: string | null;
+}
+
+/**
+ * Diff a re-imported row's enrichment cells against the stored transaction.
+ *
+ * Policy (see docs/category-reimport-plan.md §8):
+ *  - Empty incoming cell → leave unchanged (never wipe existing data on a round-trip).
+ *  - Category: compare incoming against the stored *effective* value
+ *    (`categoryOverride ?? category ?? categoryAI`); a genuine change is recorded as a
+ *    human `categoryOverride`, leaving raw `category` and AI `categoryAI` pristine.
+ *  - Notes / City: compare directly against the stored column.
+ *
+ * Returns undefined when nothing changed (so the caller can treat it as a true duplicate).
+ */
+export function computeEnrichmentDelta(
+	existing: EnrichableExisting,
+	row: NormalizedTransaction
+): EnrichmentDelta | undefined {
+	const delta: EnrichmentDelta = {};
+
+	const incomingCategory = row.category?.trim();
+	if (incomingCategory) {
+		const storedEffective =
+			existing.categoryOverride ?? existing.category ?? existing.categoryAI ?? null;
+		if (incomingCategory !== storedEffective) delta.categoryOverride = incomingCategory;
+	}
+
+	const incomingNotes = row.notes?.trim();
+	if (incomingNotes && incomingNotes !== (existing.notes ?? null)) delta.notes = incomingNotes;
+
+	const incomingCity = row.city?.trim();
+	if (incomingCity && incomingCity !== (existing.city ?? null)) delta.city = incomingCity;
+
+	return Object.keys(delta).length > 0 ? delta : undefined;
+}

--- a/src/lib/server/export/toCsv.ts
+++ b/src/lib/server/export/toCsv.ts
@@ -8,8 +8,14 @@ import type { ExportTxRow } from '$lib/server/db/queries.js';
  * (see SEMANTIC_SYNONYMS in parsers/detector.ts), so a re-imported export is
  * mapped back to the right fields. `Account` is intentionally not a parser field:
  * it is human-readable context only and is ignored on re-import.
+ *
+ * `Id` carries the internal transaction id. It is optional on re-import: when the
+ * user keeps it, the dedup engine matches on it exactly (even for identical bank
+ * rows); when they delete it, the file still re-imports via the date+amount+
+ * description baseline key.
  */
 export const EXPORT_HEADERS = [
+	'Id',
 	'Date',
 	'Amount',
 	'Description',
@@ -39,17 +45,18 @@ function toIsoDateUTC(d: Date): string {
  *
  * - Date → `yyyy-MM-dd` (UTC), a format the parser recognises and the dedup keys on.
  * - Amount → plain dot-decimal, no thousands separators (parseAmount-friendly).
- * - Category → effective value: user override takes precedence over the AI tag,
+ * - Category → effective value: human override, else raw bank value, else AI guess,
  *   matching what the /transactions page shows.
  */
 export function toCsv(rows: ExportTxRow[]): string {
 	const records = rows.map((r) => ({
+		Id: r.id,
 		Date: toIsoDateUTC(r.accountingDate),
 		Amount: String(r.amount),
 		Description: r.description,
 		Currency: r.currency,
 		Account: r.accountName ?? '',
-		Category: r.categoryOverride ?? r.category ?? '',
+		Category: r.categoryOverride ?? r.category ?? r.categoryAI ?? '',
 		Notes: r.notes ?? '',
 		City: r.city ?? ''
 	}));

--- a/src/lib/server/parsers/detector.ts
+++ b/src/lib/server/parsers/detector.ts
@@ -165,6 +165,21 @@ export const SEMANTIC_SYNONYMS: Record<SemanticField, string[]> = {
 	]
 };
 
+/**
+ * Synonyms for the optional internal-id column carried by a Clair export.
+ * Kept separate from SEMANTIC_SYNONYMS (it is not a bank-originated field that
+ * feeds normalizeRow's core mapping) and matched exactly, so a generic "id" header
+ * only maps here when it stands alone.
+ */
+export const ID_SYNONYMS = [
+	'id',
+	'transaction id',
+	'transactionid',
+	'transaction_id',
+	'tx id',
+	'txid'
+];
+
 // Priority order for field assignment (earlier = higher priority when two fields compete).
 const FIELD_PRIORITY: SemanticField[] = [
 	'date',

--- a/src/lib/server/parsers/index.ts
+++ b/src/lib/server/parsers/index.ts
@@ -7,7 +7,9 @@ import {
 	getUsedColumns,
 	CATEGORY_SYNONYMS,
 	CITY_SYNONYMS,
-	NOTES_SYNONYMS
+	NOTES_SYNONYMS,
+	ID_SYNONYMS,
+	type OptionalColumns
 } from './normalizer.js';
 import { preCategorize } from './pre-categorize.js';
 import { detectAdaptiveProfile, detectEncoding } from './detector.js';
@@ -121,6 +123,7 @@ export type ColumnOverrides = {
 	categoryColumn: string | null;
 	cityColumn: string | null;
 	notesColumn: string | null;
+	idColumn?: string | null;
 } | null;
 
 const FIELD_LABELS: Record<'category' | 'city' | 'notes', string> = {
@@ -129,28 +132,27 @@ const FIELD_LABELS: Record<'category' | 'city' | 'notes', string> = {
 	notes: 'Notes'
 };
 
-function buildOptionalColumns(
-	headers: string[],
-	overrides: ColumnOverrides
-): { categoryColumn: string | null; cityColumn: string | null; notesColumn: string | null } {
-	if (overrides) return overrides;
+function buildOptionalColumns(headers: string[], overrides: ColumnOverrides): OptionalColumns {
+	// The id column is authoritative (not a user-chosen enrichment mapping), so it is
+	// always auto-detected from the headers even when explicit overrides are supplied.
+	const idColumn = detectOptionalColumn(headers, ID_SYNONYMS);
+	if (overrides) return { ...overrides, idColumn: overrides.idColumn ?? idColumn };
 	return {
 		categoryColumn: detectOptionalColumn(headers, CATEGORY_SYNONYMS),
 		cityColumn: detectOptionalColumn(headers, CITY_SYNONYMS),
-		notesColumn: detectOptionalColumn(headers, NOTES_SYNONYMS)
+		notesColumn: detectOptionalColumn(headers, NOTES_SYNONYMS),
+		idColumn
 	};
 }
 
 function buildColumnMeta(
 	headers: string[],
 	profile: BankParserProfile,
-	optionalColumns: {
-		categoryColumn: string | null;
-		cityColumn: string | null;
-		notesColumn: string | null;
-	}
+	optionalColumns: OptionalColumns
 ): { columnMappings: ParseResult['columnMappings']; unusedColumns: string[] } {
 	const usedByProfile = getUsedColumns(profile);
+	// Includes idColumn — the id header is consumed (not surfaced as "unused") even
+	// though it is not offered as a user-facing enrichment mapping below.
 	const optionalValues = Object.values(optionalColumns).filter(Boolean) as string[];
 
 	const unusedColumns = headers.filter(

--- a/src/lib/server/parsers/normalizer.ts
+++ b/src/lib/server/parsers/normalizer.ts
@@ -1,6 +1,6 @@
 import { parse as parseDate, isValid } from 'date-fns';
 import type { BankParserProfile, NormalizedTransaction } from './types.js';
-import { SEMANTIC_SYNONYMS } from './detector.js';
+import { SEMANTIC_SYNONYMS, ID_SYNONYMS } from './detector.js';
 import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 
 // ─── Optional column synonym lists (re-exported from detector for backward compat) ──
@@ -8,6 +8,15 @@ import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 export const CATEGORY_SYNONYMS = SEMANTIC_SYNONYMS.category;
 export const CITY_SYNONYMS = SEMANTIC_SYNONYMS.city;
 export const NOTES_SYNONYMS = SEMANTIC_SYNONYMS.notes;
+export { ID_SYNONYMS };
+
+/** Shape of the optional (non-bank) columns detected from a file's headers. */
+export interface OptionalColumns {
+	categoryColumn: string | null;
+	cityColumn: string | null;
+	notesColumn: string | null;
+	idColumn: string | null;
+}
 
 /** Returns the first header that matches any synonym (case- and accent-insensitive). */
 export function detectOptionalColumn(headers: string[], synonyms: string[]): string | null {
@@ -44,11 +53,12 @@ export function getUsedColumns(profile: BankParserProfile): string[] {
 export function normalizeRow(
 	raw: Record<string, string>,
 	profile: BankParserProfile,
-	optionalColumns: {
-		categoryColumn: string | null;
-		cityColumn: string | null;
-		notesColumn: string | null;
-	} = { categoryColumn: null, cityColumn: null, notesColumn: null }
+	optionalColumns: OptionalColumns = {
+		categoryColumn: null,
+		cityColumn: null,
+		notesColumn: null,
+		idColumn: null
+	}
 ): NormalizedTransaction | null {
 	const amount = profile.amountColumn
 		? parseAmount(raw[profile.amountColumn])
@@ -96,6 +106,7 @@ export function normalizeRow(
 			: null,
 		city: optionalColumns.cityColumn ? raw[optionalColumns.cityColumn]?.trim() || null : null,
 		notes: optionalColumns.notesColumn ? raw[optionalColumns.notesColumn]?.trim() || null : null,
+		internalId: optionalColumns.idColumn ? raw[optionalColumns.idColumn]?.trim() || null : null,
 		sourceIndex: 0 // placeholder; always overwritten by the caller
 	};
 }

--- a/src/lib/server/parsers/types.ts
+++ b/src/lib/server/parsers/types.ts
@@ -83,14 +83,35 @@ export interface NormalizedTransaction {
 	category: string | null; // from CSV if user pre-filled a category column; null otherwise
 	city: string | null; // from CSV if user pre-filled a city column; null otherwise
 	notes: string | null; // from CSV if user pre-filled a notes column; null otherwise
+	internalId: string | null; // Clair transaction id echoed back by an exported+re-imported file; null otherwise
 	sourceIndex: number; // 0-based position in original file (after skipRows); used for ordering
 }
 
-export type DedupAction = 'insert' | 'update_status' | 'update_desc' | 'skip' | 'review';
+export type DedupAction =
+	| 'insert'
+	| 'update_status'
+	| 'update_desc'
+	| 'update_enrichment'
+	| 'skip'
+	| 'review';
+
+/**
+ * Enrichment delta applied on a matched row when the re-imported file carries
+ * edited Category / Notes / City values. Only non-empty incoming values that
+ * differ from the stored value are present; an absent key means "leave unchanged".
+ */
+export interface EnrichmentDelta {
+	categoryOverride?: string; // effective category changed → written as a human override
+	notes?: string;
+	city?: string;
+}
 
 export interface DedupResult {
 	action: DedupAction;
 	existingId?: string;
+	// Present when a matched row also carries edited enrichment to apply. Attached to
+	// any matching action (skip/update_status/update_desc) — the import loop applies it.
+	enrichment?: EnrichmentDelta;
 }
 
 export interface UploadSummary {

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -385,6 +385,7 @@
 											<CategorySelector
 												txId={tx.id}
 												category={tx.category}
+												categoryAI={tx.categoryAI}
 												categoryOverride={tx.categoryOverride}
 												categories={data.categories}
 											/>

--- a/src/routes/api/accounts/[id]/import/+server.ts
+++ b/src/routes/api/accounts/[id]/import/+server.ts
@@ -14,7 +14,12 @@ import {
 	detectFileDirection,
 	type ColumnOverrides
 } from '$lib/server/parsers/index.js';
-import { classifyRow, applyStatusUpdate, applyDescUpdate } from '$lib/server/dedup.js';
+import {
+	classifyRow,
+	applyStatusUpdate,
+	applyDescUpdate,
+	applyEnrichmentUpdate
+} from '$lib/server/dedup.js';
 import { upsertOpeningBalance, refreshCurrentBalance } from '$lib/server/balance.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
 import { detectAndLinkTransfers } from '$lib/server/transfer-detector.js';
@@ -92,7 +97,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 
 	let importedCount = 0;
 	let duplicateCount = 0;
+	// Counts every matched-row update (status upgrade, description change, and/or
+	// enrichment edit). Surfaced to the user as the "Updated" tile.
 	let statusUpdatesCount = 0;
+	// Subset of the above where edited Category/Notes/City were applied — for telemetry.
+	let enrichmentUpdatesCount = 0;
 	let flaggedCount = 0;
 
 	const toInsert: (typeof transactions.$inferInsert)[] = [];
@@ -108,9 +117,21 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 			flaggedCount++;
 		} else if (dedup.action === 'update_status' && dedup.existingId) {
 			await applyStatusUpdate(dedup.existingId, row);
+			if (dedup.enrichment) {
+				await applyEnrichmentUpdate(dedup.existingId, dedup.enrichment, locals.user.id);
+				enrichmentUpdatesCount++;
+			}
 			statusUpdatesCount++;
 		} else if (dedup.action === 'update_desc' && dedup.existingId) {
 			await applyDescUpdate(dedup.existingId, row);
+			if (dedup.enrichment) {
+				await applyEnrichmentUpdate(dedup.existingId, dedup.enrichment, locals.user.id);
+				enrichmentUpdatesCount++;
+			}
+			statusUpdatesCount++;
+		} else if (dedup.action === 'update_enrichment' && dedup.existingId && dedup.enrichment) {
+			await applyEnrichmentUpdate(dedup.existingId, dedup.enrichment, locals.user.id);
+			enrichmentUpdatesCount++;
 			statusUpdatesCount++;
 		} else {
 			duplicateCount++;
@@ -196,6 +217,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		imported: importedCount,
 		flagged: flaggedCount,
 		statusUpdates: statusUpdatesCount,
+		enrichmentUpdates: enrichmentUpdatesCount,
 		duplicates: duplicateCount,
 		unresolvedTransfers,
 		detectedConversions,

--- a/src/routes/api/settings/categories/[id]/+server.ts
+++ b/src/routes/api/settings/categories/[id]/+server.ts
@@ -17,8 +17,9 @@ async function getOwnedCategory(categoryId: string, workspaceId: string) {
 
 // ─── PATCH /api/settings/categories/[id] ─────────────────────────────────────
 // Update name, color, sortOrder, or parentId. Owner only.
-// When name changes: propagates to transactions.category, transactions.category_override,
-// and transaction_overrides.category within the workspace (atomic DB transaction).
+// When name changes: propagates to transactions.category, transactions.category_ai,
+// transactions.category_override, and transaction_overrides.category within the
+// workspace (atomic DB transaction).
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	if (!locals.user) throw error(401, 'Unauthorized');
@@ -105,6 +106,16 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 				SET "category_override" = ${newName}
 				FROM "core"."bank_accounts" ba
 				WHERE t."category_override" = ${oldName}
+				  AND t."bank_account_id" = ba."id"
+				  AND ba."workspace_id" = ${workspaceId}
+			`);
+
+			// Propagate to transactions.category_ai
+			await tx.execute(sql`
+				UPDATE "core"."transactions" t
+				SET "category_ai" = ${newName}
+				FROM "core"."bank_accounts" ba
+				WHERE t."category_ai" = ${oldName}
 				  AND t."bank_account_id" = ba."id"
 				  AND ba."workspace_id" = ${workspaceId}
 			`);

--- a/src/routes/api/upload/+server.ts
+++ b/src/routes/api/upload/+server.ts
@@ -2,7 +2,12 @@ import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { uploadAndParse } from '$lib/server/parsers/index.js';
 import { getAccessibleAccountIds } from '$lib/server/db/access.js';
-import { classifyRow, applyStatusUpdate, applyDescUpdate } from '$lib/server/dedup.js';
+import {
+	classifyRow,
+	applyStatusUpdate,
+	applyDescUpdate,
+	applyEnrichmentUpdate
+} from '$lib/server/dedup.js';
 import {
 	computeOpeningBalance,
 	upsertOpeningBalance,
@@ -61,7 +66,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const insertedIds: string[] = [];
 
 	for (const row of rows) {
-		const { action, existingId } = await classifyRow(row, bankAccountId);
+		const { action, existingId, enrichment } = await classifyRow(row, bankAccountId);
 
 		switch (action) {
 			case 'insert': {
@@ -94,13 +99,21 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 			case 'update_status': {
 				await applyStatusUpdate(existingId!, row);
+				if (enrichment) await applyEnrichmentUpdate(existingId!, enrichment, locals.user.id);
 				statusUpdateCount++;
 				break;
 			}
 
 			case 'update_desc': {
 				await applyDescUpdate(existingId!, row);
+				if (enrichment) await applyEnrichmentUpdate(existingId!, enrichment, locals.user.id);
 				duplicateCount++; // counts as a soft duplicate (no net-new row)
+				break;
+			}
+
+			case 'update_enrichment': {
+				await applyEnrichmentUpdate(existingId!, enrichment!, locals.user.id);
+				statusUpdateCount++;
 				break;
 			}
 

--- a/tests/export/run.ts
+++ b/tests/export/run.ts
@@ -32,23 +32,27 @@ console.log('══════════════════════�
 // Sample rows mirroring the shape of queryTransactionsForExport() output.
 const rows = [
 	{
+		id: 'tx-0001',
 		accountingDate: new Date(Date.UTC(2024, 5, 24)), // 2024-06-24
 		amount: -12.5,
 		description: 'Café La Cabra',
 		currency: 'EUR',
 		accountName: 'Revolut EUR',
-		category: 'Groceries', // AI tag
+		category: null, // no raw bank value
+		categoryAI: 'Groceries', // AI tag
 		categoryOverride: 'Coffee', // user override → wins on export
 		notes: 'CPH Day 1',
 		city: 'Copenhagen'
 	},
 	{
+		id: 'tx-0002',
 		accountingDate: new Date(Date.UTC(2024, 5, 25)), // 2024-06-25
 		amount: 1500,
 		description: 'Salary, June',
 		currency: 'EUR',
 		accountName: 'Bankinter',
 		category: null,
+		categoryAI: null,
 		categoryOverride: null,
 		notes: null,
 		city: null
@@ -71,7 +75,8 @@ assert(
 	lines.length === rows.length + 1,
 	`got: ${lines.length} lines`
 );
-assert('date formatted yyyy-MM-dd', lines[1].startsWith('2024-06-24,'), `got: ${lines[1]}`);
+assert('id column emitted first', lines[1].startsWith('tx-0001,'), `got: ${lines[1]}`);
+assert('date formatted yyyy-MM-dd', lines[1].startsWith('tx-0001,2024-06-24,'), `got: ${lines[1]}`);
 assert('amount is dot-decimal', lines[1].includes(',-12.5,'), `got: ${lines[1]}`);
 assert('effective category uses user override', lines[1].includes(',Coffee,'), `got: ${lines[1]}`);
 assert(
@@ -110,6 +115,8 @@ assert('row 0 currency round-trips', r0?.currency === 'EUR', `got: ${r0?.currenc
 assert('row 0 category = override value', r0?.category === 'Coffee', `got: ${r0?.category}`);
 assert('row 0 notes round-trips', r0?.notes === 'CPH Day 1', `got: ${r0?.notes}`);
 assert('row 0 city round-trips', r0?.city === 'Copenhagen', `got: ${r0?.city}`);
+assert('row 0 internal id round-trips', r0?.internalId === 'tx-0001', `got: ${r0?.internalId}`);
+assert('row 1 internal id round-trips', result.rows[1]?.internalId === 'tx-0002', `got: ${result.rows[1]?.internalId}`);
 
 console.log(`\n  Parsed ${result.rows.length} rows, skipped ${result.skippedCount}`);
 console.log(

--- a/tests/reimport_enrichment/run.ts
+++ b/tests/reimport_enrichment/run.ts
@@ -1,0 +1,343 @@
+#!/usr/bin/env tsx
+/**
+ * Enrichment round-trip integration test (issue #42).
+ *
+ * Exercises the export → edit → re-import contract against real Postgres:
+ *   - the real `computeEnrichmentDelta` from src (the pure diff production uses), and
+ *   - the exact tier-0 (internal id) and tier-2 (date+amount+description) matching
+ *     queries `classifyRow` runs — replicated here with a throw-away client, the same
+ *     way tests/dedup_detector/db-test.ts validates classifyRow without importing the
+ *     db-coupled module.
+ *
+ * Creates a throw-away bank account, inserts baseline transactions, then simulates a
+ * re-imported (edited) export and asserts what would be written. Cleans up on exit.
+ *
+ * Run: npx tsx tests/reimport_enrichment/run.ts
+ * Requires: docker compose up -d && a seeded user (npm run db:seed).
+ */
+
+// ── Load .env (same trick as seed-owner.ts) ───────────────────────────────
+try {
+	(process as unknown as { loadEnvFile: (p: string) => void }).loadEnvFile('.env');
+} catch {
+	/* env may already be set */
+}
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+	console.error('DATABASE_URL not set — run from project root with .env present');
+	process.exit(1);
+}
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { eq } from 'drizzle-orm';
+import { computeEnrichmentDelta } from '../../src/lib/server/enrichment.js';
+import type { NormalizedTransaction } from '../../src/lib/server/parsers/types.js';
+
+let passed = 0;
+let failed = 0;
+function assert(label: string, cond: boolean, detail?: string) {
+	if (cond) {
+		console.log(`  ✓  ${label}`);
+		passed++;
+	} else {
+		console.log(`  ✗  ${label}${detail ? ` — ${detail}` : ''}`);
+		failed++;
+	}
+}
+
+// A NormalizedTransaction with sensible defaults; override the fields a case cares about.
+function mkRow(p: Partial<NormalizedTransaction>): NormalizedTransaction {
+	return {
+		accountingDate: new Date(Date.UTC(2024, 0, 1)),
+		valueDate: null,
+		amount: 0,
+		currency: 'EUR',
+		amountOriginal: 0,
+		currencyOriginal: 'EUR',
+		description: '',
+		runningBalance: null,
+		status: 'posted',
+		rawType: null,
+		isTransferCandidate: false,
+		isFxCandidate: false,
+		category: null,
+		city: null,
+		notes: null,
+		internalId: null,
+		sourceIndex: 0,
+		...p
+	};
+}
+
+const client = postgres(DATABASE_URL);
+const schema = await import('../../src/lib/server/db/schema.js');
+const { transactions, bankAccounts } = schema;
+const db = drizzle(client, { schema });
+
+const EXISTING_COLUMNS = {
+	id: true,
+	status: true,
+	category: true,
+	categoryAI: true,
+	categoryOverride: true,
+	notes: true,
+	city: true
+} as const;
+
+// Replicates classifyRow tier-0 (internal id) then tier-2 (date+amount+description).
+async function findMatch(accountId: string, row: NormalizedTransaction) {
+	if (row.internalId) {
+		const byId = await db.query.transactions.findFirst({
+			where: (t, { and: a, eq: e }) => a(e(t.bankAccountId, accountId), e(t.id, row.internalId!)),
+			columns: EXISTING_COLUMNS
+		});
+		if (byId) return byId;
+	}
+	return db.query.transactions.findFirst({
+		where: (t, { and: a, eq: e, sql: s }) =>
+			a(
+				e(t.bankAccountId, accountId),
+				e(t.accountingDate, row.accountingDate),
+				s`${t.amount}::numeric = ${row.amount}`,
+				s`md5(${t.description}) = md5(${row.description})`
+			),
+		columns: EXISTING_COLUMNS
+	});
+}
+
+const user = await db.query.authUser.findFirst({ columns: { id: true, workspaceId: true } });
+if (!user?.workspaceId) {
+	console.error('No seeded user found — run: npm run db:seed first');
+	await client.end();
+	process.exit(1);
+}
+
+const [account] = await db
+	.insert(bankAccounts)
+	.values({
+		ownerUserId: user.id,
+		workspaceId: user.workspaceId,
+		displayName: '__ENRICH_TEST__',
+		institutionName: 'Test',
+		bankProfileId: 'revolut_eu',
+		ibanLast4: '0000',
+		currency: 'EUR'
+	})
+	.returning({ id: bankAccounts.id });
+
+console.log('\n══════════════════════════════════════════════════════════════════');
+console.log(' Enrichment round-trip — classifyRow matching + computeEnrichmentDelta');
+console.log('══════════════════════════════════════════════════════════════════\n');
+
+const D1 = new Date(Date.UTC(2024, 2, 1));
+const D2 = new Date(Date.UTC(2024, 2, 2));
+const D3 = new Date(Date.UTC(2024, 2, 3));
+
+try {
+	// ── Baseline: what a first import + AI tagging would have produced ────────
+	// A) file-provided category (raw), no AI.
+	const [txA] = await db
+		.insert(transactions)
+		.values({
+			bankAccountId: account.id,
+			accountingDate: D1,
+			amount: '-20.0000',
+			currency: 'EUR',
+			amountOriginal: '-20.0000',
+			currencyOriginal: 'EUR',
+			description: 'Grocery Store',
+			category: 'Food', // raw bank-file value
+			payerUserId: user.id
+		})
+		.returning({ id: transactions.id });
+
+	// B) no file category → AI guessed it (categoryAI only).
+	const [txB] = await db
+		.insert(transactions)
+		.values({
+			bankAccountId: account.id,
+			accountingDate: D2,
+			amount: '-10.0000',
+			currency: 'EUR',
+			amountOriginal: '-10.0000',
+			currencyOriginal: 'EUR',
+			description: 'Netflix',
+			categoryAI: 'Entertainment',
+			categoryConfidence: '0.900',
+			payerUserId: user.id
+		})
+		.returning({ id: transactions.id });
+
+	// C) two genuinely identical bank rows (same date+amount+description).
+	const [txC1] = await db
+		.insert(transactions)
+		.values({
+			bankAccountId: account.id,
+			accountingDate: D3,
+			amount: '-3.0000',
+			currency: 'EUR',
+			amountOriginal: '-3.0000',
+			currencyOriginal: 'EUR',
+			description: 'Coffee',
+			payerUserId: user.id
+		})
+		.returning({ id: transactions.id });
+	const [txC2] = await db
+		.insert(transactions)
+		.values({
+			bankAccountId: account.id,
+			accountingDate: D3,
+			amount: '-3.0000',
+			currency: 'EUR',
+			amountOriginal: '-3.0000',
+			currencyOriginal: 'EUR',
+			description: 'Coffee',
+			payerUserId: user.id
+		})
+		.returning({ id: transactions.id });
+
+	// ── 1. Re-import unchanged export → every row is a true duplicate, no delta ──
+	console.log('1. Unchanged re-import → no writes');
+	{
+		const rowA = mkRow({
+			internalId: txA.id,
+			accountingDate: D1,
+			amount: -20,
+			description: 'Grocery Store',
+			category: 'Food' // effective was 'Food' (raw)
+		});
+		const rowB = mkRow({
+			internalId: txB.id,
+			accountingDate: D2,
+			amount: -10,
+			description: 'Netflix',
+			category: 'Entertainment' // effective was the AI value
+		});
+		const mA = await findMatch(account.id, rowA);
+		const mB = await findMatch(account.id, rowB);
+		assert('row A matches the file-category row', mA?.id === txA.id);
+		assert('row B matches the AI-category row', mB?.id === txB.id);
+		assert('unchanged raw category → no delta', computeEnrichmentDelta(mA!, rowA) === undefined);
+		assert('unchanged AI category → no delta (AI not disturbed)', computeEnrichmentDelta(mB!, rowB) === undefined);
+	}
+
+	// ── 2. Edited Category → categoryOverride; raw/AI untouched ─────────────────
+	console.log('\n2. Edited Category → override, raw + AI pristine');
+	{
+		const rowA = mkRow({
+			internalId: txA.id,
+			accountingDate: D1,
+			amount: -20,
+			description: 'Grocery Store',
+			category: 'Groceries' // user changed Food → Groceries
+		});
+		const m = await findMatch(account.id, rowA);
+		const delta = computeEnrichmentDelta(m!, rowA);
+		assert('delta records the changed category as an override', delta?.categoryOverride === 'Groceries');
+		assert('delta leaves notes/city out', delta?.notes === undefined && delta?.city === undefined);
+
+		// Apply it the way the import loop would, then read back.
+		await db
+			.update(transactions)
+			.set({ categoryOverride: delta!.categoryOverride, categoryOverrideById: user.id })
+			.where(eq(transactions.id, txA.id));
+		const after = await db.query.transactions.findFirst({
+			where: eq(transactions.id, txA.id),
+			columns: { category: true, categoryAI: true, categoryOverride: true }
+		});
+		assert('categoryOverride written', after?.categoryOverride === 'Groceries');
+		assert('raw category untouched', after?.category === 'Food');
+		assert('categoryAI untouched (null)', after?.categoryAI === null);
+
+		// Re-importing the now-exported effective value ('Groceries') is idempotent.
+		const rowAgain = mkRow({
+			internalId: txA.id,
+			accountingDate: D1,
+			amount: -20,
+			description: 'Grocery Store',
+			category: 'Groceries'
+		});
+		const m2 = await findMatch(account.id, rowAgain);
+		assert('second round-trip is idempotent (no delta)', computeEnrichmentDelta(m2!, rowAgain) === undefined);
+	}
+
+	// ── 3. Edited Notes / City → those columns update; empty leaves unchanged ───
+	console.log('\n3. Edited Notes / City; empty cell leaves unchanged');
+	{
+		const rowB = mkRow({
+			internalId: txB.id,
+			accountingDate: D2,
+			amount: -10,
+			description: 'Netflix',
+			category: 'Entertainment', // unchanged effective
+			notes: 'Shared with partner',
+			city: 'Madrid'
+		});
+		const m = await findMatch(account.id, rowB);
+		const delta = computeEnrichmentDelta(m!, rowB);
+		assert('notes captured', delta?.notes === 'Shared with partner');
+		assert('city captured', delta?.city === 'Madrid');
+		assert('unchanged category not in delta', delta?.categoryOverride === undefined);
+
+		// Empty incoming cells must not wipe stored values.
+		const emptyRow = mkRow({
+			internalId: txB.id,
+			accountingDate: D2,
+			amount: -10,
+			description: 'Netflix',
+			category: '',
+			notes: '',
+			city: ''
+		});
+		assert('all-empty re-import → no delta (nothing wiped)', computeEnrichmentDelta(m!, emptyRow) === undefined);
+	}
+
+	// ── 4. Identical rows WITH distinct Id → each attributed exactly ────────────
+	console.log('\n4. Identical bank rows with distinct Id → exact per-row attribution');
+	{
+		const editC1 = mkRow({
+			internalId: txC1.id,
+			accountingDate: D3,
+			amount: -3,
+			description: 'Coffee',
+			category: 'Coffee Shops'
+		});
+		const editC2 = mkRow({
+			internalId: txC2.id,
+			accountingDate: D3,
+			amount: -3,
+			description: 'Coffee',
+			category: 'Tips'
+		});
+		const m1 = await findMatch(account.id, editC1);
+		const m2 = await findMatch(account.id, editC2);
+		assert('id routes edit 1 to coffee #1', m1?.id === txC1.id);
+		assert('id routes edit 2 to coffee #2', m2?.id === txC2.id);
+		assert('coffee #1 delta', computeEnrichmentDelta(m1!, editC1)?.categoryOverride === 'Coffee Shops');
+		assert('coffee #2 delta', computeEnrichmentDelta(m2!, editC2)?.categoryOverride === 'Tips');
+	}
+
+	// ── 5. Identical rows WITHOUT Id → best-effort, first match, no crash ───────
+	console.log('\n5. Identical bank rows without Id → best-effort (documented)');
+	{
+		const noId = mkRow({
+			accountingDate: D3,
+			amount: -3,
+			description: 'Coffee',
+			category: 'Coffee Shops'
+		});
+		const m = await findMatch(account.id, noId);
+		assert('resolves to one of the two coffees (no crash)', m?.id === txC1.id || m?.id === txC2.id);
+	}
+} finally {
+	// ── Cleanup ───────────────────────────────────────────────────────────────
+	await db.delete(transactions).where(eq(transactions.bankAccountId, account.id));
+	await db.delete(bankAccounts).where(eq(bankAccounts.id, account.id));
+	console.log('\nCleaned up test data.');
+	await client.end();
+}
+
+console.log(`\n Results: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Closes #42 
Follow-up carved out: #43 (category vs. transfer/review column conflation).

## Summary

Makes the **export → edit → re-import** round-trip actually apply user edits to `Category`,
`Notes`, and `City` back onto existing transactions — without ever disturbing the AI's guess when
nothing changed, and without re-running AI on values that already round-tripped unchanged.

To do that cleanly it also fixes the root-cause provenance problem: the `category` column used to
hold *either* the bank-file value *or* the AI prediction, indistinguishably. It is now split into
three single-source columns.

## The three-column category model

| Column | Source | Written by |
|--------|--------|-----------|
| `categoryOverride` (+ `categoryOverrideById`) | **Human** — in-app edit, or a re-import value that differs | in-app PATCH, enrichment round-trip |
| `category` | **Bank file**, exactly as imported (immutable raw); `null` when the file had none | CSV import |
| `categoryAI` (+ `categoryConfidence`) | **AI** guess — the only auto-generated one | `autoTagUpload` |

- **Resolution everywhere** (UI + export): `categoryOverride ?? category ?? categoryAI`.
- **AI auto-tag** now writes `categoryAI` and only runs when
  `categoryOverride IS NULL AND category IS NULL AND categoryAI IS NULL` (never clobbers a
  higher-trust value; never re-tags a row it already tagged).
- `buildFewShotExamples()` still learns only from `categoryOverride` (human corrections), now cleanly
  separated from bank/AI values.

## Identity & matching contract

A re-imported row is matched to an existing transaction, in order:

0. **Internal id** — if the file carries the exported `Id` column, exact match on `transactions.id`
   (scoped to the account). Authoritative; makes edit attribution exact even for identical bank rows.
1. **externalId** (bank-provided, when a profile supplies one).
2. **`accountingDate + amount + description`** — the baseline key.
3. **`accountingDate + amount`** — fallback when the description changed.

The `Id` column is **optional**: keep it for exact attribution (e.g. two €3 coffees on the same day),
delete it and the file still re-imports via the baseline key (best-effort for duplicate-keyed rows).

## Enrichment round-trip

On **any** match, an enrichment delta is computed from the re-imported row's `Category` / `Notes` /
`City` vs. the stored values:

- **Effective category** changed → written as `categoryOverride` (raw `category` and `categoryAI`
  stay pristine → provenance intact, AI stays suppressed, repeated round-trips are idempotent).
- **notes / city** changed → the column is updated.
- **Empty incoming cell → left unchanged** (never wipes data on a round-trip; clearing stays an
  in-app action).

Action mapping (preview projection and import loop kept in lock-step):
`insert → new` · `review → review` · `update_status | update_desc | update_enrichment → update` ·
`skip (no delta) → duplicate`.

## Changes by area

**Schema / migration**
- `schema.ts`: new `category_ai` column; `category` narrowed to raw-only (comments updated).
- `drizzle/migrations/0010_lonely_la_nuit.sql`: adds the column **plus a data backfill** —
  `UPDATE transactions SET category_ai = category, category = NULL WHERE category_confidence IS NOT NULL`
  — so existing AI-written rows move to `categoryAI` with **zero change to any row's effective value**.

**AI**
- `ai/auto-tag.ts`: writes `categoryAI` + `categoryConfidence`; selection guard adds `categoryAI IS NULL`.

**Resolution (3-tier) wired through**
- `db/queries.ts` (`TxRow`, `ExportTxRow` + selects), `export/toCsv.ts`, transactions page,
  `CategorySelector.svelte`.
- `api/settings/categories/[id]` rename now also propagates to `category_ai`.

**Export**
- New optional **`Id`** column (first), sourced from `transactions.id`. `Category` emits the effective
  (3-tier) value. `Notes` / `City` unchanged.

**Parser (light touch, id treated like the existing optional columns)**
- `detector.ts`: `ID_SYNONYMS` (`id`, `transaction id`, `transactionid`, `transaction_id`, `tx id`, `txid`).
- `parsers/index.ts` / `normalizer.ts` / `types.ts`: `idColumn` in `ColumnOverrides`/`OptionalColumns`,
  `internalId` on `NormalizedTransaction`. Strict bank profiles (Revolut/Bankinter) have no id → `null`.

**Dedup engine**
- `dedup.ts`: tier-0 internal-id match; `update_enrichment` action; enrichment payload attached to any
  match; `applyEnrichmentUpdate()`; `summarizeClassification` buckets `update_enrichment` into `updateCount`.
- `enrichment.ts` (new): the **pure**, db-free diff (`computeEnrichmentDelta`) — extracted so it's
  directly unit-testable without a DB connection.

**Import + counts**
- `api/accounts/[id]/import` and legacy `api/upload`: apply the enrichment branch; the "Updated" count
  now covers status/desc/enrichment updates; response adds `enrichmentUpdates` (telemetry).
- `UploadCsvDialog.svelte`: done-step tile relabeled **"Status updates" → "Updated"**.

## Testing

- `tests/export/run.ts` — extended for the `Id` column + 3-tier category. **19/19**.
- `tests/reimport_enrichment/run.ts` (new, DB-backed against Postgres) — **19/19** covering: unchanged
  re-import = no writes / AI undisturbed; edited category → `categoryOverride` with raw + AI pristine;
  idempotent second round-trip; notes/city edits; empty-cell safety; two identical rows with distinct
  `Id` → exact per-row attribution; same rows without `Id` → best-effort, no crash.
- `tests/dedup_detector/db-test.ts` — still **PASS** (no regression).
- `npm run check` — **0 errors** (pre-existing warnings only).

## Deployment notes

- Migration is **not** applied automatically anywhere (no CI, `build` = `vite build`). Run
  `drizzle-kit migrate` against each database — dev and Neon both migrated to `0010` (column + backfill).
- The `0010` file is correct for clean environments; a prior mix of `db:push` / direct SQL had left the
  local + Neon `__drizzle_migrations` tables slightly behind, which was reconciled out-of-band.

## Known follow-up

- **#43** — the transactions table renders the **Category** column as *category OR* a Transfer/Review
  badge, so transfer/review rows never display their category in the UI, while the export emits it for
  every row. Surfaced while testing this PR; tracked separately.
