### PR TITLE
Transaction fees + returned/pending status handling

### DIFF
--- a/drizzle/migrations/0011_tearful_paper_doll.sql
+++ b/drizzle/migrations/0011_tearful_paper_doll.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."transaction_status" ADD VALUE 'reverted';--> statement-breakpoint
+ALTER TABLE "core"."transactions" ADD COLUMN "fee" numeric(15, 4) DEFAULT '0' NOT NULL;

--- a/drizzle/migrations/meta/0011_snapshot.json
+++ b/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1464 @@
+{
+  "id": "01afdecd-8e19-41bd-9ac1-e99f86c2c296",
+  "prevId": "ae6faa83-53c0-4f43-9690-701f5d57aa6c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.account": {
+      "name": "account",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.session": {
+      "name": "session",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.user": {
+      "name": "user",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.verification": {
+      "name": "verification",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.bank_accounts": {
+      "name": "bank_accounts",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution_name": {
+          "name": "institution_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iban_last4": {
+          "name": "iban_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'EUR'"
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_data'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "account_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bank_accounts_workspace_id_workspaces_id_fk": {
+          "name": "bank_accounts_workspace_id_workspaces_id_fk",
+          "tableFrom": "bank_accounts",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.categories": {
+      "name": "categories",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#6b7280'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_workspace_id_workspaces_id_fk": {
+          "name": "categories_workspace_id_workspaces_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_column_mappings": {
+      "name": "csv_column_mappings",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_key": {
+          "name": "column_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_label": {
+          "name": "column_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "csv_col_map_workspace_key_uidx": {
+          "name": "csv_col_map_workspace_key_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "csv_column_mappings_workspace_id_workspaces_id_fk": {
+          "name": "csv_column_mappings_workspace_id_workspaces_id_fk",
+          "tableFrom": "csv_column_mappings",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.csv_uploads": {
+      "name": "csv_uploads",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_profile_id": {
+          "name": "bank_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged_count": {
+          "name": "flagged_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_updates": {
+          "name": "status_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opening_balance": {
+          "name": "opening_balance",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_from": {
+          "name": "date_range_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_to": {
+          "name": "date_range_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "csv_uploads_bank_account_id_bank_accounts_id_fk": {
+          "name": "csv_uploads_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "csv_uploads",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.currency_conversions": {
+      "name": "currency_conversions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_account_id": {
+          "name": "from_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_amount": {
+          "name": "from_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_amount": {
+          "name": "to_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "conversion_confidence",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "from_transaction_id": {
+          "name": "from_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_transaction_id": {
+          "name": "to_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "currency_conversions_to_account_idx": {
+          "name": "currency_conversions_to_account_idx",
+          "columns": [
+            {
+              "expression": "to_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "currency_conversions_workspace_id_workspaces_id_fk": {
+          "name": "currency_conversions_workspace_id_workspaces_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "currency_conversions_from_account_id_bank_accounts_id_fk": {
+          "name": "currency_conversions_from_account_id_bank_accounts_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "currency_conversions_to_account_id_bank_accounts_id_fk": {
+          "name": "currency_conversions_to_account_id_bank_accounts_id_fk",
+          "tableFrom": "currency_conversions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.invites": {
+      "name": "invites",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_id": {
+          "name": "invited_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_workspace_id_workspaces_id_fk": {
+          "name": "invites_workspace_id_workspaces_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "workspaces",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transaction_overrides": {
+      "name": "transaction_overrides",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tx_override_user_idx": {
+          "name": "tx_override_user_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transaction_overrides_transaction_id_transactions_id_fk": {
+          "name": "transaction_overrides_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_overrides",
+          "tableTo": "transactions",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.transactions": {
+      "name": "transactions",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_account_id": {
+          "name": "bank_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csv_upload_id": {
+          "name": "csv_upload_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accounting_date": {
+          "name": "accounting_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_eur": {
+          "name": "amount_eur",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_original": {
+          "name": "amount_original",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency_original": {
+          "name": "currency_original",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditor_name": {
+          "name": "creditor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debtor_name": {
+          "name": "debtor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_ai": {
+          "name": "category_ai",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_confidence": {
+          "name": "category_confidence",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override": {
+          "name": "category_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_override_by_id": {
+          "name": "category_override_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_transfer": {
+          "name": "is_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transfer_counterpart_id": {
+          "name": "transfer_counterpart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_by_id": {
+          "name": "transfer_linked_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_linked_at": {
+          "name": "transfer_linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_fx_candidate": {
+          "name": "is_fx_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "conversion_id": {
+          "name": "conversion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "numeric(14, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "my_portion": {
+          "name": "my_portion",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_order": {
+          "name": "original_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_opening_balance": {
+          "name": "is_opening_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "sync_source": {
+          "name": "sync_source",
+          "type": "sync_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'csv_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_dedup_idx": {
+          "name": "transactions_dedup_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_accounting_date_idx": {
+          "name": "transactions_accounting_date_idx",
+          "columns": [
+            {
+              "expression": "bank_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accounting_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_transfer_idx": {
+          "name": "transactions_transfer_idx",
+          "columns": [
+            {
+              "expression": "transfer_counterpart_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_conversion_idx": {
+          "name": "transactions_conversion_idx",
+          "columns": [
+            {
+              "expression": "conversion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_bank_account_id_bank_accounts_id_fk": {
+          "name": "transactions_bank_account_id_bank_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "bank_accounts",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "bank_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_csv_upload_id_csv_uploads_id_fk": {
+          "name": "transactions_csv_upload_id_csv_uploads_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "csv_uploads",
+          "schemaTo": "core",
+          "columnsFrom": [
+            "csv_upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "core.workspaces": {
+      "name": "workspaces",
+      "schema": "core",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_status": {
+      "name": "account_status",
+      "schema": "public",
+      "values": [
+        "no_data",
+        "active"
+      ]
+    },
+    "public.account_visibility": {
+      "name": "account_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "stats_only",
+        "full"
+      ]
+    },
+    "public.conversion_confidence": {
+      "name": "conversion_confidence",
+      "schema": "public",
+      "values": [
+        "auto",
+        "confirmed",
+        "manual"
+      ]
+    },
+    "public.sync_source": {
+      "name": "sync_source",
+      "schema": "public",
+      "values": [
+        "csv_upload",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "posted",
+        "review",
+        "reverted"
+      ]
+    }
+  },
+  "schemas": {
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785756972682,
       "tag": "0010_lonely_la_nuit",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1786003870421,
+      "tag": "0011_tearful_paper_doll",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/Amount.svelte
+++ b/src/lib/components/Amount.svelte
@@ -8,6 +8,8 @@
 		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 		showSign?: boolean;
 		colorize?: boolean;
+		/** Render struck-through and muted — used for reverted/returned transactions. */
+		struck?: boolean;
 		class?: string;
 	}
 
@@ -17,6 +19,7 @@
 		size = 'md',
 		showSign = true,
 		colorize = true,
+		struck = false,
 		class: cls = ''
 	}: Props = $props();
 
@@ -41,16 +44,20 @@
 	const sign = $derived(showSign ? (value > 0 ? '+' : value < 0 ? '−' : '') : '');
 
 	const colourClass = $derived(
-		colorize
-			? value > 0
-				? 'text-success-600'
-				: value < 0
-					? 'text-danger-600'
-					: 'text-text-secondary'
-			: ''
+		struck
+			? 'text-text-tertiary'
+			: colorize
+				? value > 0
+					? 'text-success-600'
+					: value < 0
+						? 'text-danger-600'
+						: 'text-text-secondary'
+				: ''
 	);
 </script>
 
-<span class={cn('font-mono tabular-nums', sizeMap[size], colourClass, cls)}>
+<span
+	class={cn('font-mono tabular-nums', sizeMap[size], colourClass, struck && 'line-through', cls)}
+>
 	{sign}{formatted}
 </span>

--- a/src/lib/components/Amount.svelte
+++ b/src/lib/components/Amount.svelte
@@ -33,10 +33,13 @@
 		'3xl': 'text-4xl'
 	};
 
+	// `narrowSymbol` renders ¥ / € / $ instead of the wide 3-letter code (e.g. "JPY"),
+	// keeping large amounts on one line and matching the app's symbol-first aesthetic.
 	const formatted = $derived(
 		new Intl.NumberFormat('es-ES', {
 			style: 'currency',
 			currency,
+			currencyDisplay: 'narrowSymbol',
 			minimumFractionDigits: 2
 		}).format(Math.abs(value))
 	);
@@ -57,7 +60,13 @@
 </script>
 
 <span
-	class={cn('font-mono tabular-nums', sizeMap[size], colourClass, struck && 'line-through', cls)}
+	class={cn(
+		'font-mono whitespace-nowrap tabular-nums',
+		sizeMap[size],
+		colourClass,
+		struck && 'line-through',
+		cls
+	)}
 >
 	{sign}{formatted}
 </span>

--- a/src/lib/components/CategorySelector.svelte
+++ b/src/lib/components/CategorySelector.svelte
@@ -50,7 +50,7 @@
 <Popover.Root bind:open>
 	<Popover.Trigger
 		class={cn(
-			'group flex w-full cursor-pointer justify-center outline-none',
+			'group flex w-full cursor-pointer justify-start outline-none',
 			'focus-visible:ring-1 focus-visible:ring-primary-400',
 			pending && 'opacity-50'
 		)}

--- a/src/lib/server/balance.ts
+++ b/src/lib/server/balance.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { db } from './db/index.js';
 import { transactions, bankAccounts } from './db/schema.js';
 import { PRIMARY_CURRENCY } from '$lib/currencies.js';
@@ -10,14 +10,18 @@ import { PRIMARY_CURRENCY } from '$lib/currencies.js';
 export async function computeOpeningBalance(
 	bankAccountId: string,
 	enteredCurrentBalance: number,
-	uploadedRows: { amount: number }[]
+	uploadedRows: { amount: number; status?: 'pending' | 'posted' | 'review' | 'reverted' }[]
 ): Promise<number> {
+	// Only posted rows move the real balance — pending and reverted are excluded so the
+	// derived opening balance reconciles with refreshCurrentBalance (which also sums posted).
 	const [{ sum }] = await db
 		.select({ sum: sql<string>`COALESCE(SUM(amount), 0)` })
 		.from(transactions)
-		.where(eq(transactions.bankAccountId, bankAccountId));
+		.where(and(eq(transactions.bankAccountId, bankAccountId), eq(transactions.status, 'posted')));
 
-	const uploadSum = uploadedRows.reduce((acc, r) => acc + r.amount, 0);
+	const uploadSum = uploadedRows
+		.filter((r) => (r.status ?? 'posted') === 'posted')
+		.reduce((acc, r) => acc + r.amount, 0);
 	return enteredCurrentBalance - uploadSum - parseFloat(sum);
 }
 
@@ -68,10 +72,12 @@ export async function upsertOpeningBalance(
  * Recompute and store the current balance for an account by summing all transactions.
  */
 export async function refreshCurrentBalance(bankAccountId: string): Promise<void> {
+	// Sum posted transactions only — pending and reverted rows don't affect the real balance,
+	// so Clair's current balance matches the bank app's balance.
 	const [{ sum }] = await db
 		.select({ sum: sql<string>`COALESCE(SUM(amount), 0)` })
 		.from(transactions)
-		.where(eq(transactions.bankAccountId, bankAccountId));
+		.where(and(eq(transactions.bankAccountId, bankAccountId), eq(transactions.status, 'posted')));
 
 	await db
 		.update(bankAccounts)

--- a/src/lib/server/db/queries.ts
+++ b/src/lib/server/db/queries.ts
@@ -103,12 +103,13 @@ export interface TxRow {
 	id: string;
 	accountingDate: Date;
 	description: string;
-	amount: number;
+	amount: number; // net (gross − fee)
+	fee: number; // fee portion, non-negative, in `currency`
 	currency: string;
 	amountEur: number | null;
 	exchangeRate: number | null;
 	conversionId: string | null;
-	status: 'pending' | 'posted' | 'review';
+	status: 'pending' | 'posted' | 'review' | 'reverted';
 	isTransfer: boolean;
 	isOpeningBalance: boolean;
 	notes: string | null;
@@ -220,7 +221,8 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 			? and(
 					sql`${transactions.amount}::numeric < 0`,
 					eq(transactions.isTransfer, false),
-					eq(transactions.isOpeningBalance, false)
+					eq(transactions.isOpeningBalance, false),
+					eq(transactions.status, 'posted')
 				)
 			: filter === 'transfers'
 				? eq(transactions.isTransfer, true)
@@ -241,6 +243,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 				accountingDate: transactions.accountingDate,
 				description: transactions.description,
 				amount: transactions.amount,
+				fee: transactions.fee,
 				currency: transactions.currency,
 				amountEur: transactions.amountEur,
 				exchangeRate: transactions.exchangeRate,
@@ -268,7 +271,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 				// Tab badge counts never include the opening balance row
 				all: sql<number>`COUNT(*) FILTER (WHERE NOT ${transactions.isOpeningBalance})::int`,
 				allWithOpening: sql<number>`COUNT(*)::int`,
-				expenses: sql<number>`COUNT(*) FILTER (WHERE ${transactions.amount}::numeric < 0 AND NOT ${transactions.isTransfer} AND NOT ${transactions.isOpeningBalance})::int`,
+				expenses: sql<number>`COUNT(*) FILTER (WHERE ${transactions.amount}::numeric < 0 AND NOT ${transactions.isTransfer} AND NOT ${transactions.isOpeningBalance} AND ${transactions.status} = 'posted')::int`,
 				transfers: sql<number>`COUNT(*) FILTER (WHERE ${transactions.isTransfer})::int`,
 				review: sql<number>`COUNT(*) FILTER (WHERE ${transactions.status} = 'review')::int`
 			})
@@ -298,6 +301,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 		rows: rows.map((r) => ({
 			...r,
 			amount: parseFloat(r.amount as string),
+			fee: parseFloat(r.fee as string),
 			amountEur:
 				r.currency === PRIMARY_CURRENCY
 					? parseFloat(r.amount as string)
@@ -305,7 +309,7 @@ export async function queryTransactions(params: TxQueryParams): Promise<TxQueryR
 						? parseFloat(r.amountEur as string)
 						: null,
 			exchangeRate: r.exchangeRate != null ? parseFloat(r.exchangeRate as string) : null,
-			status: r.status as 'pending' | 'posted' | 'review',
+			status: r.status as 'pending' | 'posted' | 'review' | 'reverted',
 			isOpeningBalance: r.isOpeningBalance ?? false
 		})),
 		total,

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -27,7 +27,12 @@ export const accountVisibilityEnum = pgEnum('account_visibility', [
 	'full'
 ]);
 
-export const transactionStatusEnum = pgEnum('transaction_status', ['pending', 'posted', 'review']);
+export const transactionStatusEnum = pgEnum('transaction_status', [
+	'pending',
+	'posted',
+	'review',
+	'reverted'
+]);
 
 export const syncSourceEnum = pgEnum('sync_source', ['csv_upload', 'cron', 'manual']);
 
@@ -132,7 +137,11 @@ export const transactions = coreSchema.table(
 		accountingDate: timestamp('accounting_date', { mode: 'date' }).notNull(),
 		valueDate: timestamp('value_date', { mode: 'date' }),
 
+		// Net signed effect on the balance (gross − fee). Drives all balance/P&L aggregations.
 		amount: numeric('amount', { precision: 15, scale: 4 }).notNull(),
+		// Fee/commission portion, stored as a non-negative value in `currency`. A fee is always
+		// a cost: net `amount` = gross − fee. Gross is derivable as `amount + fee`.
+		fee: numeric('fee', { precision: 15, scale: 4 }).default('0').notNull(),
 		currency: text('currency').notNull(),
 		amountEur: numeric('amount_eur', { precision: 15, scale: 4 }),
 		amountOriginal: numeric('amount_original', { precision: 15, scale: 4 }),

--- a/src/lib/server/dedup.ts
+++ b/src/lib/server/dedup.ts
@@ -10,7 +10,27 @@ import { computeEnrichmentDelta, type EnrichableExisting } from './enrichment.js
  */
 interface ExistingRow extends EnrichableExisting {
 	id: string;
-	status: 'pending' | 'posted' | 'review';
+	status: 'pending' | 'posted' | 'review' | 'reverted';
+}
+
+/**
+ * Decide whether an incoming row's status finalises an existing one.
+ * Returns the new status to apply, or null when there is nothing to change.
+ *
+ *  - pending → posted / reverted: a provisional row settled (or was returned).
+ *  - posted  → reverted:          a settled charge was later returned/cancelled.
+ *
+ * We never downgrade (posted → pending), never un-revert, and leave `review` rows to
+ * manual resolution.
+ */
+function statusTransition(
+	existing: ExistingRow['status'],
+	incoming: NormalizedTransaction['status']
+): NormalizedTransaction['status'] | null {
+	if (existing === incoming) return null;
+	if (existing === 'pending' && (incoming === 'posted' || incoming === 'reverted')) return incoming;
+	if (existing === 'posted' && incoming === 'reverted') return 'reverted';
+	return null;
 }
 
 const EXISTING_COLUMNS = {
@@ -94,7 +114,7 @@ export async function classifyRow(
 	if (sameAmountDate.length === 1) {
 		const existing = sameAmountDate[0];
 		const enrichment = computeEnrichmentDelta(existing, row);
-		if (existing.status === 'pending' && row.status === 'posted')
+		if (statusTransition(existing.status, row.status))
 			return { action: 'update_status', existingId: existing.id, enrichment };
 		// Description changed (out of contract) — still apply enrichment on this branch.
 		return { action: 'update_desc', existingId: existing.id, enrichment };
@@ -110,7 +130,7 @@ export async function classifyRow(
  */
 function resolveExactMatch(existing: ExistingRow, row: NormalizedTransaction): DedupResult {
 	const enrichment = computeEnrichmentDelta(existing, row);
-	if (existing.status === 'pending' && row.status === 'posted')
+	if (statusTransition(existing.status, row.status))
 		return { action: 'update_status', existingId: existing.id, enrichment };
 	if (enrichment) return { action: 'update_enrichment', existingId: existing.id, enrichment };
 	return { action: 'skip' };
@@ -161,8 +181,9 @@ export async function summarizeClassification(
 }
 
 /**
- * Apply a PENDING → POSTED status upgrade.
- * Only touches system-owned fields. Never overwrites category, notes, city, tags.
+ * Apply a status transition (pending → posted/reverted, or posted → reverted).
+ * Refreshes the bank-owned fields that can change on settlement (status, amount, fee,
+ * valueDate). Only touches system-owned fields — never category, notes, city, tags.
  */
 export async function applyStatusUpdate(
 	existingId: string,
@@ -171,7 +192,9 @@ export async function applyStatusUpdate(
 	await db
 		.update(transactions)
 		.set({
-			status: 'posted',
+			status: row.status,
+			amount: row.amount.toFixed(4),
+			fee: row.fee.toFixed(4),
 			valueDate: row.valueDate,
 			updatedAt: new Date()
 			// Intentionally NOT updating: category, categoryOverride, notes, city, tags

--- a/src/lib/server/parsers/detector.ts
+++ b/src/lib/server/parsers/detector.ts
@@ -117,6 +117,19 @@ export const SEMANTIC_SYNONYMS: Record<SemanticField, string[]> = {
 		'available balance'
 	],
 	status: ['status', 'estado', 'state', 'statut', 'zustand'],
+	fee: [
+		'fee',
+		'fees',
+		'comisión',
+		'comision',
+		'comisiones',
+		'charge',
+		'charges',
+		'commission',
+		'gebühr',
+		'gebuhr',
+		'frais'
+	],
 	type: [
 		'type',
 		'tipo',
@@ -192,6 +205,7 @@ const FIELD_PRIORITY: SemanticField[] = [
 	'credit',
 	'status',
 	'type',
+	'fee',
 	'localAmount',
 	'category',
 	'city',
@@ -676,6 +690,7 @@ function buildResolvedProfile(
 		currencyColumn: m('currency'),
 		localAmountColumn: m('localAmount'),
 		balanceColumn: m('balance'),
+		feeColumn: m('fee'),
 		statusColumn: m('status'),
 		typeColumn: m('type'),
 		transferTypes: [],

--- a/src/lib/server/parsers/index.ts
+++ b/src/lib/server/parsers/index.ts
@@ -13,11 +13,7 @@ import {
 } from './normalizer.js';
 import { preCategorize } from './pre-categorize.js';
 import { detectAdaptiveProfile, detectEncoding } from './detector.js';
-import {
-	revolut_eu,
-	postNormalize as revolut_eu_postNormalize,
-	REVOLUT_EU_HEADER_FINGERPRINT
-} from './profiles/revolut_eu.js';
+import { revolut_eu, REVOLUT_EU_HEADER_FINGERPRINT } from './profiles/revolut_eu.js';
 import { bankinter_es, BANKINTER_ES_HEADER_FINGERPRINT } from './profiles/bankinter_es.js';
 
 // ─── Profile registry ──────────────────────────────────────────────────────
@@ -102,11 +98,11 @@ export function detectFileDirection(
 
 // ─── Per-profile post-normalise hooks ─────────────────────────────────────
 
+// Per-profile escape hatch for adjustments the generic normalizer can't express.
+// Fees are now handled generically via `profile.feeColumn`, so there are no entries today.
 const POST_NORMALIZE: Partial<
 	Record<string, (row: NormalizedTransaction, raw: Record<string, string>) => NormalizedTransaction>
-> = {
-	revolut_eu: revolut_eu_postNormalize
-};
+> = {};
 
 // ─── Parse ────────────────────────────────────────────────────────────────
 

--- a/src/lib/server/parsers/normalizer.ts
+++ b/src/lib/server/parsers/normalizer.ts
@@ -42,6 +42,7 @@ export function getUsedColumns(profile: BankParserProfile): string[] {
 		profile.currencyColumn,
 		profile.localAmountColumn,
 		profile.balanceColumn,
+		profile.feeColumn,
 		profile.statusColumn,
 		profile.typeColumn,
 		...profile.additionalColumns
@@ -60,9 +61,14 @@ export function normalizeRow(
 		idColumn: null
 	}
 ): NormalizedTransaction | null {
-	const amount = profile.amountColumn
+	const grossAmount = profile.amountColumn
 		? parseAmount(raw[profile.amountColumn])
 		: parseAmount(raw[profile.creditColumn!] ?? '') - parseAmount(raw[profile.debitColumn!] ?? '');
+
+	// Fee/commission is always a cost, stored non-negative. Net effect on the balance is
+	// gross − fee (uniform for income and expenses), so we fold it into `amount` at parse time.
+	const fee = profile.feeColumn ? Math.abs(parseAmount(raw[profile.feeColumn] ?? '')) : 0;
+	const amount = grossAmount - fee;
 
 	const accountingDate = parseDateField(raw[profile.dateColumn], profile.dateFormat);
 	if (!accountingDate) return null; // unparseable date → skip row
@@ -71,9 +77,9 @@ export function normalizeRow(
 		? parseDateField(raw[profile.valueDateColumn], profile.dateFormat)
 		: null;
 
-	const statusRaw = profile.statusColumn ? raw[profile.statusColumn]?.trim().toUpperCase() : null;
-	const status: 'pending' | 'posted' =
-		statusRaw && ['PENDIENTE', 'PENDING'].includes(statusRaw) ? 'pending' : 'posted';
+	const status = classifyStatus(
+		profile.statusColumn ? raw[profile.statusColumn]?.trim().toUpperCase() : null
+	);
 
 	const rawType = profile.typeColumn ? (raw[profile.typeColumn]?.trim() ?? null) : null;
 
@@ -88,6 +94,7 @@ export function normalizeRow(
 		accountingDate,
 		valueDate,
 		amount,
+		fee,
 		currency: profile.currencyColumn
 			? raw[profile.currencyColumn]?.trim() || PRIMARY_CURRENCY
 			: PRIMARY_CURRENCY,
@@ -109,6 +116,29 @@ export function normalizeRow(
 		internalId: optionalColumns.idColumn ? raw[optionalColumns.idColumn]?.trim() || null : null,
 		sourceIndex: 0 // placeholder; always overwritten by the caller
 	};
+}
+
+// Bank status vocabularies, normalised to UPPERCASE. `reverted` is an umbrella for any
+// transaction whose money was returned / never settled (returned, cancelled, declined, failed).
+const PENDING_STATES = ['PENDIENTE', 'PENDING'];
+const REVERTED_STATES = [
+	'DEVUELTO',
+	'REVERTED',
+	'RETURNED',
+	'CANCELLED',
+	'CANCELED',
+	'CANCELADO',
+	'RECHAZADO',
+	'DECLINED',
+	'FAILED'
+];
+
+/** Map a raw (upper-cased) bank status string to Clair's status. Unknown → posted. */
+export function classifyStatus(statusRaw: string | null | undefined): 'pending' | 'posted' | 'reverted' {
+	if (!statusRaw) return 'posted';
+	if (PENDING_STATES.includes(statusRaw)) return 'pending';
+	if (REVERTED_STATES.includes(statusRaw)) return 'reverted';
+	return 'posted';
 }
 
 function parseDateField(raw: string | undefined, format: string): Date | null {

--- a/src/lib/server/parsers/profiles/bankinter_es.ts
+++ b/src/lib/server/parsers/profiles/bankinter_es.ts
@@ -18,6 +18,7 @@ export const bankinter_es: BankParserProfile = {
 	currencyColumn: 'Divisa',
 	localAmountColumn: null,
 	balanceColumn: 'Saldo',
+	feeColumn: null, // Bankinter bakes any fees into the amount / separate rows
 	statusColumn: null, // all exported rows are posted
 	typeColumn: null, // Bankinter exports do not include an operation type column
 	transferTypes: [],

--- a/src/lib/server/parsers/profiles/revolut_eu.ts
+++ b/src/lib/server/parsers/profiles/revolut_eu.ts
@@ -1,5 +1,4 @@
-import type { BankParserProfile, NormalizedTransaction } from '../types.js';
-import { parseAmount } from '../normalizer.js';
+import type { BankParserProfile } from '../types.js';
 
 export const revolut_eu: BankParserProfile = {
 	fileType: 'csv',
@@ -19,6 +18,8 @@ export const revolut_eu: BankParserProfile = {
 	currencyColumn: 'Divisa',
 	localAmountColumn: null, // Revolut only exports the EUR-equivalent amount
 	balanceColumn: 'Saldo',
+	// Fee/commission, positive in the row's currency; the normalizer folds it in as gross − fee.
+	feeColumn: 'Comisión',
 	statusColumn: 'State',
 	typeColumn: 'Tipo',
 	// 'Transferir' = outgoing/incoming peer transfers.
@@ -27,25 +28,8 @@ export const revolut_eu: BankParserProfile = {
 	transferTypes: ['Transferir', 'Recargas'],
 	// 'Cambio' marks a cross-currency exchange (e.g. EUR → SEK top-up).
 	fxCandidateTypes: ['Cambio'],
-	additionalColumns: ['Comisión'] // used in postNormalize to add fees to amount
+	additionalColumns: []
 };
-
-/**
- * Revolut-specific post-normalisation adjustments:
- * - Adds fee (Comisión) to amount if non-zero
- * - Leaves everything else as-is from the generic normalizer
- */
-export function postNormalize(
-	row: NormalizedTransaction,
-	raw: Record<string, string>
-): NormalizedTransaction {
-	const fee = parseAmount(raw['Comisión'] ?? '');
-	if (fee !== 0) {
-		// Fee is already signed (negative) in Revolut exports; add it to amount
-		return { ...row, amount: row.amount + fee };
-	}
-	return row;
-}
 
 /**
  * Fingerprint to auto-detect a Revolut EU (Spanish) CSV from its header row.

--- a/src/lib/server/parsers/types.ts
+++ b/src/lib/server/parsers/types.ts
@@ -12,6 +12,7 @@ export type SemanticField =
 	| 'balance'
 	| 'status'
 	| 'type'
+	| 'fee'
 	| 'category'
 	| 'city'
 	| 'notes';
@@ -52,6 +53,7 @@ export interface BankParserProfile {
 	currencyColumn: string | null;
 	localAmountColumn: string | null; // original-currency amount (cross-currency txns)
 	balanceColumn: string | null; // running balance (empty for PENDING rows)
+	feeColumn: string | null; // fee/commission column in the row's currency (e.g. Revolut 'Comisión')
 	statusColumn: string | null; // e.g. 'COMPLETADO'/'PENDIENTE'
 	typeColumn: string | null; // raw transaction type (e.g. Revolut 'Tipo')
 	transferTypes: string[]; // typeColumn values that flag a row as a transfer candidate
@@ -70,13 +72,14 @@ export interface ResolvedProfile extends BankParserProfile {
 export interface NormalizedTransaction {
 	accountingDate: Date;
 	valueDate: Date | null; // null when transaction is pending
-	amount: number;
+	amount: number; // net signed effect on the balance (gross − fee)
+	fee: number; // fee/commission portion, non-negative, in `currency`; 0 when none
 	currency: string;
 	amountOriginal: number;
 	currencyOriginal: string;
 	description: string;
 	runningBalance: number | null; // null when transaction is pending
-	status: 'pending' | 'posted';
+	status: 'pending' | 'posted' | 'reverted';
 	rawType: string | null; // original type string from CSV
 	isTransferCandidate: boolean; // derived from rawType + profile.transferTypes
 	isFxCandidate: boolean; // derived from rawType + profile.fxCandidateTypes

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -80,7 +80,9 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 				and(
 					inArray(transactions.bankAccountId, accessibleIds),
 					gte(transactions.accountingDate, thirtyDaysAgo),
-					eq(transactions.isOpeningBalance, false)
+					eq(transactions.isOpeningBalance, false),
+					// Only settled transactions affect the real net change — exclude pending/reverted.
+					eq(transactions.status, 'posted')
 				)
 			)
 			.groupBy(transactions.bankAccountId),

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -28,6 +28,15 @@
 
 	let { data }: { data: PageData } = $props();
 
+	/** Small "incl. ¥21 fee" hint for rows that carried a fee/commission. */
+	function formatFee(value: number, currency: string): string {
+		return new Intl.NumberFormat('es-ES', {
+			style: 'currency',
+			currency,
+			minimumFractionDigits: 2
+		}).format(value);
+	}
+
 	// ── Local state ────────────────────────────────────────────────────────────
 
 	let searchInput = $state(data.filters.q);
@@ -305,6 +314,8 @@
 					<tbody>
 						{#each data.rows as tx (tx.id)}
 							{@const isReview = tx.status === 'review'}
+							{@const isReverted = tx.status === 'reverted'}
+							{@const isPending = tx.status === 'pending'}
 							{@const isTransfer = tx.isTransfer}
 							{@const isOpening = tx.isOpeningBalance}
 
@@ -359,7 +370,8 @@
 								<tr
 									class={cn(
 										'border-b border-border transition-colors hover:bg-surface-sunken/60',
-										isReview && 'border-l-2 border-l-amber-400'
+										isReview && 'border-l-2 border-l-amber-400',
+										isReverted && 'opacity-60'
 									)}
 								>
 									<!-- Category col: status label or CategorySelector -->
@@ -408,6 +420,21 @@
 												<AlertTriangle size={13} class="shrink-0 text-amber-500" />
 											{/if}
 											<span class="truncate text-xs font-medium md:text-sm">{tx.description}</span>
+											{#if isPending}
+												<Badge
+													variant="outline"
+													class="shrink-0 border-amber-200 bg-amber-50 text-[10px] font-medium text-amber-700"
+												>
+													Pending
+												</Badge>
+											{:else if isReverted}
+												<Badge
+													variant="outline"
+													class="shrink-0 text-[10px] font-medium text-text-tertiary"
+												>
+													Returned
+												</Badge>
+											{/if}
 											{#if tx.notes}
 												<NoteHint note={tx.notes} />
 											{/if}
@@ -433,7 +460,18 @@
 
 									<!-- Amount col -->
 									<td class="px-2 py-2 text-right md:px-4 md:py-3">
-										<Amount value={tx.amount} currency={tx.currency} size="xs" class="md:text-sm" />
+										<Amount
+											value={tx.amount}
+											currency={tx.currency}
+											size="xs"
+											struck={isReverted}
+											class="md:text-sm"
+										/>
+										{#if tx.fee > 0}
+											<div class="mt-0.5 text-[10px] text-text-tertiary md:text-xs">
+												incl. {formatFee(tx.fee, tx.currency)} fee
+											</div>
+										{/if}
 										{#if tx.currency !== PRIMARY_CURRENCY}
 											{#if tx.amountEur != null}
 												<div class="mt-0.5 text-text-tertiary">

--- a/src/routes/(app)/transactions/+page.svelte
+++ b/src/routes/(app)/transactions/+page.svelte
@@ -28,13 +28,12 @@
 
 	let { data }: { data: PageData } = $props();
 
-	/** Small "incl. ¥21 fee" hint for rows that carried a fee/commission. */
-	function formatFee(value: number, currency: string): string {
-		return new Intl.NumberFormat('es-ES', {
-			style: 'currency',
-			currency,
-			minimumFractionDigits: 2
-		}).format(value);
+	/**
+	 * Bare number for the "incl. 21,00 fee" hint — no currency code, since the fee is always in
+	 * the same currency as the amount shown directly above it (keeps the line short + single-row).
+	 */
+	function formatFee(value: number): string {
+		return new Intl.NumberFormat('es-ES', { minimumFractionDigits: 2 }).format(value);
 	}
 
 	// ── Local state ────────────────────────────────────────────────────────────
@@ -285,7 +284,7 @@
 					<thead class="sticky top-0 z-10 bg-surface-sunken shadow-[0_1px_0_0_var(--border)]">
 						<tr>
 							<th
-								class="w-20 px-2 py-2.5 text-left text-[10px] font-semibold tracking-wider text-text-tertiary uppercase md:w-36 md:px-4"
+								class="w-28 px-2 py-2.5 text-left text-[10px] font-semibold tracking-wider text-text-tertiary uppercase md:w-36 md:px-4"
 							>
 								Category
 							</th>
@@ -305,7 +304,7 @@
 								Account
 							</th>
 							<th
-								class="w-24 px-2 py-2.5 text-right text-[10px] font-semibold tracking-wider text-text-tertiary uppercase md:w-32 md:px-4"
+								class="w-28 px-2 py-2.5 text-right text-[10px] font-semibold tracking-wider text-text-tertiary uppercase md:w-40 md:px-4"
 							>
 								Amount
 							</th>
@@ -324,7 +323,10 @@
 								<tr class="border-b border-border bg-surface-sunken/40 opacity-70">
 									<!-- Category col: opening balance label -->
 									<td class="px-2 py-2 md:px-4 md:py-3">
-										<Badge variant="outline" class="text-[11px] font-medium text-text-tertiary">
+										<Badge
+											variant="outline"
+											class="max-w-full min-w-0 shrink truncate text-[11px] font-medium text-text-tertiary"
+										>
 											Opening balance
 										</Badge>
 									</td>
@@ -377,18 +379,18 @@
 									<!-- Category col: status label or CategorySelector -->
 									<td class="px-2 py-2 md:px-4 md:py-3">
 										{#if isReview}
-											<div class="flex justify-center">
+											<div class="flex justify-start">
 												<Badge
-													class="border-amber-200 bg-amber-100 text-[11px] font-medium text-amber-700"
+													class="max-w-full min-w-0 shrink truncate border-amber-200 bg-amber-100 text-[11px] font-medium text-amber-700"
 												>
 													Review Required
 												</Badge>
 											</div>
 										{:else if isTransfer}
-											<div class="flex justify-center">
+											<div class="flex justify-start">
 												<Badge
 													variant="outline"
-													class="text-[11px] font-medium text-text-secondary"
+													class="max-w-full min-w-0 shrink truncate text-[11px] font-medium text-text-secondary"
 												>
 													Transfer
 												</Badge>
@@ -468,8 +470,10 @@
 											class="md:text-sm"
 										/>
 										{#if tx.fee > 0}
-											<div class="mt-0.5 text-[10px] text-text-tertiary md:text-xs">
-												incl. {formatFee(tx.fee, tx.currency)} fee
+											<div
+												class="mt-0.5 truncate text-[10px] whitespace-nowrap text-text-tertiary md:text-xs"
+											>
+												incl. {formatFee(tx.fee)} fee
 											</div>
 										{/if}
 										{#if tx.currency !== PRIMARY_CURRENCY}

--- a/src/routes/api/accounts/[id]/import/+server.ts
+++ b/src/routes/api/accounts/[id]/import/+server.ts
@@ -285,7 +285,7 @@ function buildTxInsert(
 	bankAccountId: string,
 	csvUploadId: string,
 	payerUserId: string,
-	status: 'pending' | 'posted' | 'review'
+	status: 'pending' | 'posted' | 'review' | 'reverted'
 ): typeof transactions.$inferInsert {
 	return {
 		bankAccountId,
@@ -293,6 +293,7 @@ function buildTxInsert(
 		accountingDate: row.accountingDate,
 		valueDate: row.valueDate,
 		amount: row.amount.toFixed(4),
+		fee: row.fee.toFixed(4),
 		currency: row.currency,
 		amountOriginal: row.amountOriginal.toFixed(4),
 		currencyOriginal: row.currencyOriginal,

--- a/tests/fees/run.ts
+++ b/tests/fees/run.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env tsx
+/**
+ * Revolut fees + status parser test.
+ *
+ * Asserts that:
+ *  - fees (Comisión) are extracted into `fee` (non-negative) and folded into `amount` as gross − fee,
+ *  - Revolut states map correctly (COMPLETADO→posted, PENDIENTE→pending, DEVUELTO→reverted),
+ *  - summing only the POSTED net amounts reconciles to the file's final Saldo (35622),
+ *    i.e. the reverted and pending rows are excluded from the balance.
+ *
+ * Run: npx tsx tests/fees/run.ts
+ */
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dataDir = join(__dirname, 'data');
+
+const { parseCSV, getProfile } = await import('../../src/lib/server/parsers/index.js');
+
+const profile = getProfile('revolut_eu');
+if (!profile) throw new Error('revolut_eu profile not found');
+
+const csvText = readFileSync(join(dataDir, 'revolut-fake-fees-and-returned.csv'), 'utf8');
+const { rows, skippedCount, errors } = parseCSV(csvText, profile);
+
+let failures = 0;
+function check(label: string, actual: unknown, expected: unknown) {
+	const ok = actual === expected;
+	if (!ok) failures++;
+	console.log(`  ${ok ? '✓' : '✗'} ${label}: got ${JSON.stringify(actual)}${ok ? '' : ` (expected ${JSON.stringify(expected)})`}`);
+}
+
+const byDesc = (desc: string, amount: number) =>
+	rows.find((r) => r.description === desc && Math.round(r.amount) === amount);
+
+console.log('\n══════════════════════════════════════════════════════════════════════════════');
+console.log(' REVOLUT FEES + STATUS');
+console.log('══════════════════════════════════════════════════════════════════════════════');
+
+console.log(`\n  Parsed ${rows.length} rows | skipped ${skippedCount} | errors ${errors.length}`);
+
+// ── Fee extraction (stored positive, folded into net amount) ────────────────
+console.log('\n Fee extraction (net = gross − fee):');
+const sushi = byDesc('MMO Sushi', -2157);
+check('MMO Sushi net amount', sushi?.amount, -2157);
+check('MMO Sushi fee', sushi?.fee, 21);
+
+const baili = byDesc('Bai Li Food 1688', -964);
+check('Bai Li net amount', baili?.amount, -964);
+check('Bai Li fee', baili?.fee, 10);
+
+const conv = byDesc('Conversión a JPY', 45740);
+check('Zero-fee row fee is 0', conv?.fee, 0);
+
+// ── Status mapping ───────────────────────────────────────────────────────────
+console.log('\n Status mapping:');
+check('COMPLETADO → posted', byDesc('Bootleggers', -2975)?.status, 'posted');
+check('PENDIENTE → pending', byDesc('Uber', -100)?.status, 'pending');
+check('DEVUELTO → reverted', byDesc('Bolt', -479)?.status, 'reverted');
+
+// ── Balance reconciliation (posted-only) ─────────────────────────────────────
+console.log('\n Reconciliation (posted-only net sum == final Saldo):');
+const postedSum = rows.filter((r) => r.status === 'posted').reduce((s, r) => s + r.amount, 0);
+check('Σ posted net amounts', Math.round(postedSum), 35622);
+
+const allSum = rows.reduce((s, r) => s + r.amount, 0);
+console.log(`  (all-status sum would be ${Math.round(allSum)} — includes excluded reverted/pending)`);
+
+console.log('\n──────────────────────────────────────────────────────────────────────────────');
+if (failures > 0) {
+	console.log(` ${failures} assertion(s) FAILED ✗`);
+	process.exit(1);
+}
+console.log(' All assertions passed ✓\n');

--- a/tests/reimport_enrichment/run.ts
+++ b/tests/reimport_enrichment/run.ts
@@ -53,6 +53,7 @@ function mkRow(p: Partial<NormalizedTransaction>): NormalizedTransaction {
 		accountingDate: new Date(Date.UTC(2024, 0, 1)),
 		valueDate: null,
 		amount: 0,
+		fee: 0,
 		currency: 'EUR',
 		amountOriginal: 0,
 		currencyOriginal: 'EUR',


### PR DESCRIPTION
Closes #46.

Makes Clair's numbers match the bank app by handling two things the CSV pipeline got wrong, both surfaced by `tests/fees/data/revolut-fake-fees-and-returned.csv`.

## Fees

Revolut exports a fee in a separate `Comisión` column, positive, in the transaction's own currency. The old `postNormalize` folded it in as `amount + fee` (assuming a negative fee) — wrong for real exports.

- New `fee` column on `transactions` (non-negative).
- `net = gross − fee`, computed once at parse time and stored in `amount`, so every existing `SUM(amount)` stays correct. Gross is derivable as `amount + fee`.
- Promoted fees to a first-class, reusable `feeColumn` on the parser profile (works for future banks + adaptive detection), and deleted Revolut's buggy hook.

Proof: summing only the **posted** net amounts reproduces the file's `Saldo` exactly → `45740 −2975 −2157 −964 −2011 −2011 = 35622`.

## Status (returned / pending)

`DEVUELTO` was silently counted as a settled expense.

- Added a `reverted` status; states now map `COMPLETADO→posted`, `PENDIENTE→pending`, `DEVUELTO→reverted`.
- **Pending and reverted are excluded from all balance / P&L / expense aggregations** (only `posted` counts) — `balance.ts`, `queries.ts`, and the dashboard net-change sum. Rows stay visible for the audit trail.
- Dedup gained the pending→posted/reverted and posted→reverted transitions.

## UI

- Reverted rows: muted + struck-through amount with a "Returned" badge; pending rows get a "Pending" pill; a fee shows an `incl. 21,00 fee` hint.
- Fixed Amount-column overflow: currency now renders as a narrow symbol (`¥ € $`) instead of the 3-letter code, amounts stay single-line, and the column was widened.
- Fixed Category-column clipping on mobile: wider column, left-aligned badges, and shrink/truncate so pills stay contained.

## Migration

`0011` — adds the `fee` column (default 0) and the `reverted` enum value. Additive and non-destructive; no backfill. Run `npm run db:generate` (already generated) then `npm run db:migrate`.

> Note: historical Revolut rows imported before this fix have a wrong `amount` and `fee = 0`; a clean re-import corrects them.
